### PR TITLE
RJTT ACA

### DIFF
--- a/final/AS/JPN/RJTT.txt
+++ b/final/AS/JPN/RJTT.txt
@@ -1,8 +1,5 @@
-# This is an automatically generated airport file for Endless ATC.
-# Feel free to improve, use and share this file, at your own risk.
-# Data from ourairports.com.
-# Coastline from naturalearthdata.com.
-# See the example.txt airport for all possible sections and items to add to this file.
+# RJTT ACA 1.3.1
+# See RJTT_readme.md
 
 [airspace]
 radius = 100

--- a/final/AS/JPN/RJTT.txt
+++ b/final/AS/JPN/RJTT.txt
@@ -485,7 +485,7 @@ airlines =
 	abl, 2, a320/a321/a21n, air busan, w
 	aci, 1, a339, air calin, e
 	aca, 1, b77w/b788/b789, air canada, ne
-	cca, 2, a332/a333/b772
+	cca, 2, a332/a333/b772, air china, w
 	afr, 1, b77w, air france, n
 	aic, 1, b788, air india, w
 	amu, 1, a320/a20n/a321/a20n, air macau, w

--- a/final/AS/JPN/RJTT.txt
+++ b/final/AS/JPN/RJTT.txt
@@ -1,0 +1,3907 @@
+# This is an automatically generated airport file for Endless ATC.
+# Feel free to improve, use and share this file, at your own risk.
+# Data from ourairports.com.
+# Coastline from naturalearthdata.com.
+# See the example.txt airport for all possible sections and items to add to this file.
+
+[airspace]
+radius = 100
+zoom = 1
+elevation = 21
+floor = 900
+descendaltitude = 14000
+ceiling = 24000
+above = 28000
+transitionaltitude = 13999
+speedrestriction = 100, 250
+usa = false
+metric = false
+center = N035.38, E140.35
+magneticvar = -6.468
+beacons =
+#VORS
+	HME, N035.33.44.340, E139.45.40.140, 0, Hah Neh Dah
+	XAC, N034.42.44.110, E139.24.50.460, 98, O shima
+	SYE, N036.00.39.330, E139.50.21.020, 0, Seh Kee Yah Doh
+	NRE, N035.46.56.440, E140.21.45.130, 0, Nah Ree Tah
+	HUC, N036.11.13.220, E140.24.49.420, 0, Hya Koo Ree
+	HKE, N35.48.51.00, E140.22.17.81, 0, Hokuso
+#RJTT
+	AKSEL, N034.40.39.520, E139.51.26.910, 39, Aksel
+	AROSA, N034.42.01.720, E140.41.57.290, 0, Arosa
+	POLIX, N036.12.37.060, E140.26.22.530, -310, Polix
+	GODIN, N036.24.25.340, E140.16.55.890, 197, Godin
+#	TEDIX, N036.37.51.810, E140.19.37.410, -197, Tedix
+	MILIT, N035.56.46.790, E141.13.08.890, -278, Milit
+	RUNSO, N034.29.16.720, E139.43.04.910, 74, Runso
+	KAIHO, N35.18.57.83, E139.46.42.43, 353, Kai ho
+	ARLON, N35.15.25.28, E139.58.59.79, -9, Arlon 
+	WEDGE, N35.09.00.44, E139.58.46.52, -300, Wedge
+	CIVIC, N35.08.40.58, E140.25.52.07, 345, Civic
+	ACORN, N34.50.28.82, E139.41.46.71, -68, Acorn
+	CREAM, N35.17.43.35, E140.06.12.42, 291, Cream
+	AVEEY, N34.41.55.89, E140.21.57.97, 314, Aveey
+	COLOR, N36.01.16.32, E140.12.19.80, 197, Color
+	COACH, N35.37.36.01, E140.12.31.48, 185, Coach
+	KASGA, N35.54.24.66, E139.49.15.60, 16, Kasuga
+	UTIBO, N34.56.47.02, E139.53.43.90, -357, Uchibo
+	STING, N34.51.57.89, E140.14.53.44, 67, Sting
+	SHAFT, N35.22.27.42, E140.13.13.31, 330, Shaft
+	NYLON, N35.40.18.54, E140.09.19.89, -357, Nylon
+	NOVEL, N36.21.06.94, E140.00.04.91, -264, Novel
+	SCREW, N36.03.01.23, E139.54.00.39, -203, Screw
+	MESSE, N35.11.00.76, E140.22.14.70, -246, Messe
+	CHIBA, N35.35.22.20, E140.03.59.96, 91, Chee Bah
+	CACAO, N35.22.12.81, E139.55.30.14, 332, Cacao
+	CHIPS, N36.12.47.70, E140.14.36.89, 0, Chips
+#LDA 22 STAR fixes
+#	BACON, N35.31.55.02, E140.12.15.07, -3, Bacon
+#	BONUS, N35.36.19.97, E140.07.09.57, 277, Bonus
+#LDA 23 STAR fixes
+#	DREAD, N36.03.59.19, E139.58.56.94, 191, Dread
+#	DENNY, N35.48.28.80, E140.05.56.37, 167, Denny
+#	DOYLE, N35.34.17.15, E140.07.10.51, -277, Doyle
+#	DARKS, N35.34.14.83, E139.59.02.94, -274, Darks
+#16L STAR fixes
+#	SNARE, N35.47.31.09, E139.52.38.14, 297, Snare
+#	SPINE, N35.42.13.47, E140.11.25.82, -348, Spine
+#	SNOKE, N35.35.51.64, E140.14.11.69, 92, Snoke
+#16R star fixes
+#	NUMAN, N35.47.14.43, E140.12.04.93, -360, Numan
+#	NEURO, N35.57.27.61, E139.54.41.30, 290, Neuro
+#	STONE, N36.16.46.51, E140.15.24.40, 216, Stone
+#	SINGO, N35.15.08.49, E140.00.29.08, 334, Singo
+#	ADDUM, N34.53.29.49, E140.14.20.69, 337, Addum
+#RJAA
+	SUPOK, N35.46.14.13, E141.28.10.04, 276, Supok
+#	GURIP, N36.33.16.42, E140.37.36.49, -205, Gurip
+	SWAMP, N36.19.14.44, E140.32.17.02, -205, Swamp
+	LUBLA, N35.32.35.04, E141.25.50.78, 341, Lubla
+	RUTAS, N34.43.49.26, E140.40.34.19, 65, Rutas
+	BAFFY, N34.20.42.40, E139.58.31.13, 65, Baffy
+	VENUS, N35.04.40.08, E140.43.09.73, 13, Venus
+	AQUOS, N35.12.29.74, E141.09.42.49, 37, Aquos
+	TYLER, N35.26.50.48, E140.38.07.77, -337, Tyler
+	PEAKS, N35.25.07.15, E140.43.52.65, -298, Peaks
+	ELGAR, N35.31.29.20, E140.45.27.39, 223, Elgar
+	COPEN, N35.33.03.70, E140.49.39.17, 18, Copen
+	CORGI, N35.38.29.77, E140.51.38.90, 223, Corgi
+	GAUDI, N35.30.02.42, E141.04.18.10, 358, Gaudi
+	BARON, N35.45.51.02, E141.01.11.97, 277, Baron
+	KARMA, N35.50.42.86, E140.55.12.44, -168, Karma
+	CASIO, N35.50.21.35, E140.35.56.06, 316, Casio
+	NORMA, N35.59.00.83, E140.32.53.97, 308, Norma
+	GEMIN, N35.57.38.61, E140.24.50.74, 317, Gemin
+	PLEIA, N36.07.34.84, E140.47.45.41, 141, Pleia
+	ABBOT, N35.49.13.93, E141.05.07.20, 276, Abbot
+	SWIMY, N35.25.50.28, E141.14.07.32, 305, Swimy
+	LAKES, N35.57.50.90, E140.30.01.36, -282, Lakes
+	PIXUS, N36.07.08.49, E140.10.35.18, 256, Pixus
+#FAF
+#	COSMO, N35.34.36.41, E140.30.38.59, 0, Cosmo
+#	LAPIS, N35.34.37.27, E140.32.33.16. 0, Lapis
+#NON-RNAV fixes
+#	BINKS, N35.11.16.31, E140.43.56.67, 340, Binks
+
+boundary = 
+#2
+	N034.23.37.000, E139.00.33.000
+#3
+	N034.11.53.000, E139.12.55.000
+#4
+	N034.11.41.000, E139.59.54.000
+#5
+	N034.16.14.000, E140.12.35.000
+#16
+	N034.48.16.000, E141.44.17.000
+#17
+	N036.05.00.000, E141.46.04.000
+#39
+	N036.05.03.000, E141.00.17.000
+#48
+	N036.19.13.000, E140.41.25.000
+#54
+	N036.29.38.000, E140.51.26.000
+#55
+	N036.35.40.000, E140.28.12
+#47
+	N036.36.11, E140.26.10
+#42
+	N036.37.52, E140.19.37
+#6
+	N036.34.29, E140.13.17
+#7
+	N36.25.15, E139.56.33
+#8
+	N35.59.18, E139.44.24
+#59
+	N36.02.23, E139.18.42
+#56
+	N35.56.26, E139.09.39
+#57
+	N35.43.16, E139.04.33
+#58
+	N35.21.34, E139.08.12
+#14
+	N34.56.14, E139.12.25
+#15
+	N34.54.12, E138.59.49
+
+line1 =
+	N37.11465, E141.00166
+	N37.00205, E140.96836
+	N36.92573, E140.89512
+	N36.89033, E140.83965
+	N36.84687, E140.79180
+	N36.73188, E140.72988
+	N36.50278, E140.62734
+	N36.44531, E140.61885
+	N36.38560, E140.61924
+	N36.30781, E140.59160
+	N36.23135, E140.57354
+	N36.14243, E140.59043
+	N36.05923, E140.62197
+	N35.84570, E140.75957
+	N35.78252, E140.81348
+	N35.72495, E140.87402
+	N35.66128, E140.63926
+	N35.63203, E140.59688
+	N35.51025, E140.45742
+	N35.39478, E140.41289
+	N35.26699, E140.41650
+	N35.22114, E140.39297
+	N35.18145, E140.35469
+	N35.15503, E140.31475
+	N35.09648, E140.15889
+	N35.03828, E140.05918
+	N34.94731, E139.95977
+	N34.89961, E139.92041
+	N34.91489, E139.84395
+	N34.95693, E139.79922
+	N35.00986, E139.84326
+	N35.07217, E139.82969
+	N35.23232, E139.85146
+	N35.29668, E139.82646
+	N35.34526, E139.90615
+	N35.42300, E139.94414
+	N35.48521, E140.02715
+	N35.54043, E140.08633
+	N35.58516, E140.09688
+	N35.63335, E140.04365
+	N35.66821, E139.98750
+	N35.66836, E139.90977
+	N35.65806, E139.83477
+	N35.61211, E139.78633
+	N35.54956, E139.77012
+	N35.52036, E139.77393
+	N35.49482, E139.76777
+	N35.40913, E139.65000
+	N35.31948, E139.66553
+	N35.27397, E139.70000
+	N35.25239, E139.74404
+	N35.22153, E139.73086
+	N35.14927, E139.67500
+	N35.14214, E139.63594
+	N35.24326, E139.56406
+	N35.29854, E139.47441
+	N35.29810, E139.36348
+	N35.27803, E139.24941
+	N35.21074, E139.16270
+	N35.15488, E139.13408
+	N35.09712, E139.11582
+	N34.95649, E139.12197
+	N34.83916, E139.08604
+	N34.73604, E139.01562
+	N34.69839, E138.98262
+	N34.62842, E138.89668
+	N34.61924, E138.83750
+	N34.65103, E138.79512
+	N34.69922, E138.76104
+	N34.87573, E138.80449
+	N34.97480, E138.80273
+	N35.02524, E138.90361
+	N35.09570, E138.82090
+	N35.12407, E138.71963
+	N35.08647, E138.57715
+	N35.04414, E138.53701
+	N34.98716, E138.50957
+	N34.91519, E138.43311
+	N34.84771, E138.34863
+	N34.73267, E138.25322
+	N34.59634, E138.18906
+	N34.64092, E137.97900
+
+line2 =
+	N34.77544, E139.37002
+	N34.72051, E139.36689
+	N34.68989, E139.39238
+	N34.67954, E139.44570
+	N34.72651, E139.45645
+	N34.77588, E139.42617
+	N34.77544, E139.37002
+
+[airport1]
+name = Tokyo International Airport
+code = RJTT
+runways =
+#A RWY
+	rwy1, 34L, N035.32.11.760, E139.47.08.410, 329.88, 9842.52, 0, 1574.8, 18, 3, 329.88, 3.5, 149.88
+#B RWY
+	rwy2, 22, N035.34.02.880, E139.46.37.610, 215.01, 8200, 0, 0, 35
+#C RWY
+	rwy3, 34R, N035.32.22.90, E139.48.18.490, 329.88, 11023.62, 1181.1, 1279.53, 21, 3, 329.88, 3.5, 149.88
+#	rwy7, 34R, N035.32.22.90, E139.48.18.490, 329.88, 11023.62, 1181.1, 1279.53, 21, 3, 329.88, 3.5, 149.88
+#D RWY
+	rwy4, 23, N035.32.26.150, E139.49.19.610, 222.56, 8200, 0, 0, 55, 3, 224.56
+
+climbaltitude = 15000
+
+sids = 
+	BEKLA, N35.49.58.66, E139.10.09.50, Bekla
+	RITLA, N35.39.44.78, E139.08.13.11, Ritla
+	NINOX, N35.29.53.44, E139.09.53.06, Ninox
+	KAGNA, N34.59.16.28, E138.59.03.81, Kagna
+#	AKAGI, N36.23.28.33, E139.41.56.28, Akagi
+	CLARK, N36.07.02.03, E139.48.00.47, Clark
+	AGRIS, N36.25.14.70, E139.56.33.13, Agris
+	GULBO, N35.26.32.86, E141.45.09.55, Gulbo
+	BORLO, N35.16.33.77, E141.44.55.61, Borlo
+	NURLI, N34.11.51.14, E139.29.47.90, Nurli
+#only for drawing minor fixes
+	VAMOS, N35.12.15.47, E139.45.43.64, Vamos
+	LAXAS, N35.01.53.07, E139.14.32.78, Laxas
+	ROVER, N35.59.18.31, E139.50.59.27, Rover
+	SELNO, N034.17.03.620, E139.07.28.680, Selno
+	DOLBA, N034.42.02.980, E141.26.07.080, Dolba
+	LALID, N035.56.38.750, E141.45.52.070, Lalid
+	SPENS, N034.42.53.370, E139.00.05.460, Spens
+	TEDIX, N036.37.51.810, E140.19.37.410, Tedix
+	LUTNA, N034.17.53.600, E140.09.33.98, Lutna
+	RURER, N034.29.24.72, E140.42.01.15, Rurer
+	ANSAD, N34.41.47.92, E141.42.44.41, Ansad
+	RUSDA, N035.56.47.490, E140.57.29.870, Rusda
+	ESKEN, N036.05.01.090, E140.41.22.760, Esken
+	TOPIT, N034.11.41.450, E139.59.42.200, Topit
+
+entrypoints = 
+#Y71 SPENS Y71 XAC
+#	235, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+	240, XAC
+#Y21 SELNO Y21 AKSEL
+	220, RUNSO
+	220, RUNSO
+	220, RUNSO
+	220, RUNSO
+	220, RUNSO
+	220, RUNSO
+#Y824 DOLBA Y824 AROSA
+	122, AROSA
+#Y87 TOPIT Y875 AROSA
+	194, AROSA
+#Y10 GODIN
+	0, GODIN
+	0, GODIN
+	0, GODIN
+	0, GODIN
+	0, GODIN
+	0, GODIN
+	0, GODIN
+#Y807 LALID Y807 POLIX
+	65, MILIT
+
+airlines = 
+#rjcc
+	ana, 6, b763/b772/b773/b788/b789, all neeppon, n
+	jal, 7, b763/b772/b773/b788/b789/a359, japan air, n
+	ado, 5, b737/b763, air do, n
+	sky, 3, b738, skymark, n
+#rjoo
+	ana, 8, b763/b772/b773/b788/b789, all neeppon, w
+	jal, 8, b763/b772/b773/b788/b789/a359, japan air, w
+#roah
+	ana, 4, b763/b772/b773/b788/b789, all neeppon, w
+	jal, 4, b763/b772/b773/b788/b789/a359, japan air, w
+#rjff
+	ana, 4, b763/b772/b773/b788/b789, all neeppon, w
+	jal, 6, b763/b772/b773/b788/b789/a359, japan air, w
+	sfj, 4, a320, star flyer, w
+#domestic
+	ana, 2, b772/b773/b789, all neeppon, nsw
+	ana, 4, b763/b788, all neeppon, nsw
+	ana, 7, b737/b738/a320/a321/a21n, all neeppon, nsw
+	jal, 2, b772/b773/a359, japan air, nsw
+	jal, 4, b763/b788, japan air, nsw
+	jal, 7, b738, japan air, nsw
+	ado, 2, b737/b763, air do, n
+	sky, 5, b738, skymark, nw
+	sfj, 4, a320, star flyer, w
+	snj, 4, b738, new sky, w
+#international
+	ana, 5, b763/b77w/b788/b789/b78x, all neeppon, nswe
+	jal, 5, a359/b763/b772/b77w/b788/b789, japan air, nswe
+	afl, 1, b77w, aeroflot, n
+	xax, 1, a333, xanadu, s
+	aca, 1, a333/b789/b77w, air canada, e
+	cca, 1, a332/a333, air china, w
+	afr, 1, b77w, air france, n
+	aza, 1, a332, alitalia, n
+	aal, 1, b789, american, e
+	aar, 2, a333, asiana, w
+	baw, 1, b788/b77w, speedbird, n
+	cpa, 2, a35k, cathay, w
+	cal, 2, a333, dynasty, w
+	ces, 1, a333, china eastern, w
+	csn, 1, a333/b789/b77w, china southern, w
+	dal, 3, a333/a339/a359/b772, delta, ne
+	uae, 1, b77l/b77w, emirates, w
+	eva, 2, a333, eva, w
+	fin, 1, a359, finnair, n
+	gia, 1, a333/b77w, indonesia, s
+	chh, 1, b738, hainan, w
+	hal, 1, a332, hawaiian, e
+	hke, 1, a321, hong kong express, w
+	dkh, 1, a320, air juneyao, w
+	kal, 2, b772/b773, korean air, w
+	dlh, 1, a343/b748, lufthansa, n
+	oka, 1, b738/b739, okayjet, w
+	apj, 3, a320, air peach, w
+	pal, 1, a359, philippine, w
+	qfa, 1, a333, kwan tahs, s
+	qtr, 1, a359/a35k, qatar, w
+	sbi, 1, a20n, siberian, n
+	sas, 1, a359, scandinavian, n
+	cdg, 1, b738, shandong, w
+	csh, 1, a333/b789, shanghai air, w
+	sia, 1, a359/b77w, singapore, w
+	cqh, 1, a320, air spring, w
+	tha, 1, b744, thai, w
+	gcr, 1, a333, bohai, w
+	ttw, 1, a320, smart cat, w
+	thy, 1, b789, turkish, n
+	ual, 3, b772/b788/b789/b78x, united, ne
+	vjc, 1, a321, viet jet air, w
+	hvn, 1, a359, vietnam airlines, w
+#cargo
+	ana, 3, b763, all neeppon, w
+	ana, 1, b77l, all neeppon, w
+#jasdf
+#	jf-1, 1, b77w, japan air force, nswe
+	cygns-1, 1, b77w, sig nus, nswe
+#jcg
+#	ja-500a, 1, glf5, 0, nsw
+#ga
+#	ja-123a, 1, c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-12ab, 1, c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+	ja-1234, 1, c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-123a, 1, be58/p46t/t206/c172/kodi/p68/pa46/c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-12ab, 1, be58/p46t/t206/c172/kodi/p68/pa46/c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-1234, 1, be58/p46t/t206/c172/kodi/p68/pa46/c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+
+[airport2]
+name = Narita International Airport
+code = AA
+inboundbeacon = NRE
+traffic = 3
+
+runways =
+#A RWY
+	rwy5, 34L, N35.44.35.96, E140.23.26.66, 329.51, 13123.36, 0, 0, 135
+#	rwy8, 34L, N35.44.35.96, E140.23.26.66, 329.51, 13123.36, 0, 0, 135
+#B RWY
+	rwy6, 34R, N35.47.08.82, E140.23.31.72, 329.51, 8202.1, 0, 0, 137
+#	rwy9, 34R, N35.47.08.82, E140.23.31.72, 329.51, 8202.1, 0, 0, 137
+
+climbaltitude = 7000
+
+sids = 
+	KIMIN, N36.31.19.50, E140.07.38.18, Kimin
+	TEPEX, N36.00.14.77, E138.52.57.90, Tepex
+	OLVAN, N35.12.14.13, E141.01.11.31, Olvan
+	NORIS, N34.34.26.56, E141.04.08.49, Noris
+	MITOP, N35.19.10.75, E138.55.50.43, Mitop
+	SEDRI, N35.09.13.54, E138.57.27.34, Sedri
+	IRNOK, N34.38.32.89, E141.15.58.24, Irnok
+#only for drawing minor fixes, overridden later
+	INUBO, N35.43.35.29, E140.47.57.94, Inubo
+	LESPO, N35.46.36.00, E141.45.37.79, Lespo
+	VAGLA, N35.01.33.45, E141.44.34.81, Vagla
+	MAMAS, N34.27.33.98, E140.08.57.99, Mamas
+	GURIP, N36.33.16.42, E140.37.36.49, Gurip
+
+entrypoints = 
+#Y81 RUTAS/Y87 BAFFY Y81 RUTAS
+#	200, RUTAS
+	200
+	200
+	200
+	200
+	200
+	200
+	200
+	200
+#Y813 LUBLA
+#	110, LUBLA
+	110
+#Y30 SWAMP/(R211 SWAMP)
+#	12, SWAMP
+	12
+	12
+	12
+	12
+#Y809 SUPOK
+#	73, SUPOK
+	73
+
+airlines = 
+	ana, 8, b77w, all neeppon, nse
+	ana, 10, b788/b789, all neeppon, nwse
+	ana, 3, a20n/a21n, all neeppon, w
+	ana, 3, b763, all neeppon, nws
+	ana, 2, a388, all neeppon, e
+	jal, 4, b763, japan air, nsw
+	jal, 10, b772/b788/b789, japan air, nsw
+	jal, 6, b77w, japan air, nwe
+	jal, 3, b738, japan air, w
+	jjp, 6, a320, orange liner, w 
+	jjp, 1, a320, orange liner, s
+	jjp, 1, a320, orange liner, n
+	apj, 4, a320/a20n, air peach, w
+	apj, 1, a320/a20n, air peach, n
+	sky, 2, b738, skymark, w
+	sky, 1, b738, skymark, s
+	sjo, 3, b738, j spring, w
+	sjo, 1, b738, j spring, n
+	amx, 1, b788, aero mexico, e
+	xax, 1, a333, xanadu, s
+	abl, 2, a320/a321/a21n, air busan, w
+	aci, 1, a339, air calin, e
+	aca, 1, b77w/b788/b789, air canada, ne
+	cca, 2, a332/a333/b772
+	afr, 1, b77w, air france, n
+	aic, 1, b788, air india, w
+	amu, 1, a320/a20n/a321/a20n, air macau, w
+	anz, 1, b789, new zealand, se
+	asv, 1, a321, air seoul, w
+	tht, 1, b789, tahiti airlines, e
+	aal, 1, b788/b77w, american, e
+	aar, 2, a321/a388, asiana, nw
+	shu, 1, a319, aurora, n
+	aua, 1, b772, austrian, n
+	bav, 1, a21n/b789, bamboo, w
+	cpa, 2, a359/a35k/b773/b77w, cathay, w
+	ceb, 1, a320/a20n/a333, cebu air, s
+	cal, 2, a333/a359, dynasty, w
+	ces, 1, a333/a359/b77w, china eastern, w
+	ces, 1, a319/a320/a20n/a321, china eastern, w
+	csn, 1, a388, china southern, w
+	csn, 1, b77w, china southern, w
+	csn, 1, a320/a20n/a321, china southern, w
+	drk, 1, a319/a20n, royal bhutan, w
+	esr, 1, b738, eastar jet, nw
+	msr, 1, b77w, egypt air, w
+	ely, 1, b789, el al, w
+	uae, 1, a388, emirates, w
+	eth, 1, b788/b789, ethiopian, w
+	etd, 1, b789, etihad, w
+	eva, 2, b789, eva, w
+	fji, 1, a332, fiji, e
+	fin, 1, a359, finnair, n
+	gia, 1, b77w, indonesia, s
+	chh, 1, a333, hainan, w
+	hal, 1, a332, hawaiian, e
+	hke, 1, a321, hong kong express, w
+	crk, 1, a332/a333, bauhinia, w
+	ibe, 1, a359, iberia, w
+	jja, 1, b738, che ju air, nw
+	jst, 1, b788, jet star, s
+	jna, 1, b738, jin air, nw
+	dkh, 1, b789, air juneyao, w
+	klm, 1, b772/b77w, k l m, n
+	kal, 2, a332/a333/b789, korean air, w
+	lot, 1, b788/b789, pollot, n
+	mas, 1, a359/a388, malaysian, w
+	mda, 1, e190, mandarin, w
+	mgl, 1, b738, mongol air, nw
+	rna, 1, a332, royal nepal, w
+	pia, 1, b772, pakistan, n
+	pal, 1, a321/a20n/a333/a359, philippine, w
+	qfa, 1, a333, kwan tahs, s
+	rba, 1, a20n, brunei, s
+	sbi, 1, a320/a20n, siberian, n
+	vsv, 1, b763, vlasta, n
+	tgw, 1, a320/b788/b789, scooter, w
+	csz, 1, b738/a333, shenzhen air, w
+	csc, 1, a332, sichaun, w
+	sia, 1, b78x, singapore, w
+	cqh, 1, a20n, air spring, w
+	alk, 1, a333, srilankan, w
+	swr, 1, b77w, swiss, n
+	tax, 1, a333, express wing, w
+	tha, 1, a359/b772/b77w, thai, w
+	tlm, 1, a333/a339, mentari, e
+	ttw, 1, a320, smart cat, w
+	thy, 1, a333/b77w, turkish, n
+	twb, 1, b738, teeway, nw
+	ual, 2, b772/b77w/b789, united, e
+	ual, 1, b738, united, s
+	uzb, 1, a20n, uzbek, n
+	vjc, 1, a20n, viet jet air, w
+	hvn, 1, a359/b78x, vietnam airlines, w
+	hvn, 1, a321/a21n, vietnam airlines, w
+	cxa, 1, b789, xiamen air, w
+	cxa, 1, b738, xiamen air, w
+	tzp, 1, b788, zipair, nwe
+#cargo
+	ana, 4, b763, all neeppon, nws
+	ana, 2, b77l, all neeppon, nws
+	cao, 2, b744/b77l, air china freight, w
+	afr, 1, b77l, air france, n
+	ahk, 1, a306, air hong kong, w
+	abw, 1, b744/b748, air bridge cargo, nw
+	aar, 1, b744, asiana, nw
+	clx, 1, b748, cargolux, nw
+	icv, 1, b744, cargolux italia, nw
+	cpa, 2, b744/b748, cathay, w
+	cal, 1, b744, dynasty, w
+	ckk, 1, b77l, cargo king, w
+	box, 2, b77l, german cargo, nwe
+	uae, 1, b77l, emirates, w
+	eva, 1, b77l, eva, w
+	fdx, 4, b77l, fed ex, nswe
+	fdx, 1, md11, fed ex, nswe
+	fdx, 1, a306, fed ex, w
+	klm, 1, b744, k l m, n
+	kal, 1, b748, korean air, w
+	gec, 1, b77l, lufthansa cargo, n
+	mas, 1, a332, malaysian, w
+	nca, 6, b744/b748, nippon cargo, nswe
+	pac, 3, b744/b748, polar
+	qtr, 1, b77l, qatar, w
+	sia, 1, b744, singapore, w
+	ups, 3, b763, u p s, nswe
+	hyt, 1, b733, quick air, w
+#ga
+	ja-123a, 1, c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+	ja-12ab, 1, c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+	ja-1234, 1, c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-123a, 1, be58/p46t/t206/c172/kodi/p68/pa46/c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-12ab, 1, be58/p46t/t206/c172/kodi/p68/pa46/c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+#	ja-1234, 1, be58/p46t/t206/c172/kodi/p68/pa46/c25m/c525/c25a/hdjt/glf5/glf6, 0, nswe
+
+#[airport3]
+#name = Chofu Airport
+#code = TF
+#inboundbeacon = RB
+
+#TOKYO CTR 3000/GND / TOKYO PCA NR1 4000/3000 (EXC 3000)
+[area1]
+shape = circle
+altitude = 4001
+radius = 5
+position = N35.33.12, E139.46.52
+labelpos = N35.33.22, E139.43.52
+
+#TOKYO PCA NR1 SOUTH 4000/700
+[area2]
+shape = polygon
+altitude = 4001
+draw = 1
+labelpos = N35.29.00, E139.50.43
+points = 
+#7
+	N35.30.49, E139.52.16
+#10
+	N35.28.25, E139.53.58
+#9
+	N35.25.57, E139.48.45
+#8
+	N35.28.12, E139.47.09
+
+#TOKYO PCA NR1 SOUTH 5000/1000
+[area3]
+shape = polygon
+altitude = 5001
+draw = 1
+labelpos = N35.26.50, E139.52.53
+points = 
+#10
+	N35.28.25, E139.53.58
+#16
+	N35.26.15, E139.55.31
+#15
+	N35.23.47, E139.50.18
+#9
+	N35.25.57, E139.48.45
+
+#TOKYO PCA NR1 SOUTH 6000/1500
+[area4]
+shape = polygon
+altitude = 6001
+draw = 1
+labelpos = N35.24.15, E139.51.25
+points = 
+#16
+	N35.26.15, E139.55.31
+#22
+	N35.24.56, E139.56.27
+#21
+	N35.22.28, E139.51.14
+#15
+	N35.23.47, E139.50.18
+
+#TOKYO PCA NR1 SOUTH 6000/2000
+[area5]
+shape = polygon
+altitude = 6001
+draw = 1
+labelpos = N35.23.0, E139.54.40
+points = 
+#22
+	N35.24.56, E139.56.27
+#28
+	N35.22.25, E139.58.14
+#27
+	N35.19.57, E139.53.00
+#21
+	N35.22.28, E139.51.14
+
+#TOKYO PCA NR1 SOUTH 6000/2500
+[area6]
+shape = polygon
+altitude = 6001
+draw = 1
+labelpos = N35.21.10, E139.56.27
+points = 
+#28
+	N35.22.25, E139.58.14
+#36
+	N35.20.48, E139.59.23
+#35
+	N35.18.20, E139.54.09
+#27
+	N35.19.57, E139.53.00
+
+#TOKYO PCA NR1 SOUTH 6000/3000
+[area7]
+shape = polygon
+altitude = 6001
+draw = 1
+labelpos = N35.19.50, E139.57.40
+points = 
+#36
+	N35.20.48, E139.59.23
+#43
+	N35.19.04, E140.00.36
+#42
+	N35.16.36, E139.55.22
+#35
+	N35.18.20, E139.54.09
+
+#TOKYO PCA NR1 EAST 4000/700
+[area8]
+shape = polygon
+altitude = 4001
+draw = 1
+labelpos = N35.35.09, E139.53.00
+points = 
+#2
+	N35.38.11, E139.47.11
+#1
+	N35.40.02, E139.48.46
+#6
+	N35.37.58, E139.52.35
+#5
+	N35.35.09, E139.56.05
+#4
+	N35.32.15, E139.56.06
+#3
+	N35.32.13, E139.52.53
+
+#TOKYO PCA NR1 EAST 5000/1000
+[area9]
+shape = polygon
+altitude = 5001
+draw = 3
+labelpos = N35.40.02, E139.51.53
+points = 
+#1
+	N35.40.02, E139.48.46
+#11
+	N35.42.09, E139.50.37
+#14
+	N35.39.49, E139.54.50
+#13
+	N35.37.01, E139.58.21
+#12
+	N35.32.15, E139.58.22
+#4
+	N35.32.15, E139.56.06
+#5
+	N35.35.09, E139.56.05
+#6
+	N35.37.58, E139.52.35
+
+#TOKYO PCA NR1 EAST 6000/1500
+[area10]
+shape = polygon
+altitude = 6001
+draw = 3
+labelpos = N35.42.50, E139.51.30
+points = 
+#11
+	N35.42.09, E139.50.37
+#17
+	N35.43.37, E139.51.53
+#20
+	N35.41.05, E139.56.23
+#19
+	N35.38.17, E139.59.53
+#18
+	N35.32.16, E139.59.55
+#12
+	N35.32.15, E139.58.22
+#13
+	N35.37.01, E139.58.21
+#14
+	N35.39.49, E139.54.50
+
+#TOKYO PCA NR1 EAST 6000/2000
+[area11]
+shape = polygon
+altitude = 6001
+draw = 3
+labelpos = N35.43.37, E139.55.26
+points = 
+#17
+	N35.43.37, E139.51.53
+#23
+	N35.45.46, E139.53.44
+#26
+	N35.42.57, E139.58.39
+#25
+	N35.40.09, E140.02.09
+#24
+	N35.32.17, E140.02.12
+#18
+	N35.32.16, E139.59.55
+#19
+	N35.38.17, E139.59.53
+#20
+	N35.41.05, E139.56.23
+
+#TOKYO PCA NR1 EAST 6000/2500
+[area12]
+shape = polygon
+altitude = 6001
+draw = 3
+labelpos = N35.38.17, E140.02.25
+points = 
+#23
+	N35.45.46, E139.53.44
+#29
+	N35.46.10, E139.54.04
+#34
+	N35.45.23, E139.55.26
+#33
+	N35.45.55, E139.57.33
+#32
+	N35.45.02, E139.59.05
+#31
+	N35.38.18, E140.04.41
+#30
+	N35.32.17, E140.04.44
+#24
+	N35.32.17, E140.02.12
+#25
+	N35.40.09, E140.02.09
+#26
+	N35.42.57, E139.58.39
+
+#TOKYO PCA NR1 EAST 6000/3000
+[area13]
+shape = polygon
+altitude = 6001
+draw = 3
+labelpos = N35.43.12, E140.03.00
+points = 
+#33
+	N35.45.55, E139.57.33
+#37
+	N35.46.40, E140.00.57
+#41
+	N35.46.00, E140.02.16
+#40
+	N35.43.12, E140.05.47
+#39
+	N35.38.18, E140.07.08
+#38
+	N35.32.18, E140.07.11
+#30
+	N35.32.17, E140.04.44
+#31
+	N35.38.18, E140.04.41
+#32
+	N35.45.02, E139.59.05
+
+#TOKYO PCA NR1 EAST 6000/3500
+[area14]
+shape = polygon
+altitude = 6001
+draw = 3
+labelpos = N35.47.40, E139.56.00
+points = 
+#29
+	N35.46.10, E139.54.04
+#44
+	N35.48.57, E139.56.29
+#37
+	N35.46.40, E140.00.57
+#33
+	N35.45.55, E139.57.33
+#34
+	N35.45.23, E139.55.26
+
+#TOKYO PCA NR2 4000/700 (EXC 4000 & 700)
+[area15]
+shape = polygon
+altitude = 4000
+draw = 1
+labelpos = N35.39.00, E139.44.20
+points = 
+#47
+	N35.35.53, E139.41.41
+#46
+	N35.37.32, E139.40.31
+#45
+	N35.40.00, E139.45.44
+#48
+	N35.38.12, E139.47.00
+
+#TOKYO PCA NR2 4000/1000 (EXC 4000 & 1000)
+[area16]
+shape = polygon
+altitude = 4000
+draw = 1
+labelpos = N35.39.00, E139.40.47
+points = 
+#46
+	N35.37.32, E139.40.31
+#50
+	N35.38.50, E139.39.35
+#49
+	N35.41.19, E139.44.48
+#45
+	N35.40.00, E139.45.44
+
+#TOKYO PCA NR2 4500/1500 (EXC 4500 & 1500)
+[area17]
+shape = polygon
+altitude = 4500
+draw = 1
+labelpos = N35.41.0, E139.40.47
+points = 
+#50
+	N35.38.50, E139.39.35
+#53
+	N35.38.56, E139.39.31
+#52
+	N35.40.41, E139.39.47
+#51
+	N35.42.39, E139.43.57
+#54
+	N35.42.27, E139.44.00
+#49
+	N35.41.19, E139.44.48
+
+#TOKYO PCA NR2 6000/2000 (EXC 6000 & 2000)
+[area18]
+shape = polygon
+altitude = 6000
+draw = 1
+labelpos = N35.44.00, E139.41.00
+points = 
+#52
+	N35.40.41, E139.39.47
+#55
+	N35.47.17, E139.40.47
+#56
+	N35.45.15, E139.43.23
+#51
+	N35.42.39, E139.43.57
+
+#NARITA CTR 3000/GND
+[area19]
+shape = circle
+altitude = 3001
+name = AA
+radius = 5
+position = N35.45.55, E140.23.08
+labelpos = N35.47.55, E140.25.58
+draw = 2.45, 7.65
+
+#NARITA CTR 3000/GND
+[area20]
+shape = polygon
+altitude = 3001
+name = AA
+draw = 1
+#labelpos = N35.19.04, E139.57.00
+points = 
+	N35.50.54, E140.23.41
+	N35.52.38, E140.22.25
+	N35.49.57, E140.16.47
+	N35.48.26, E140.17.49
+
+#NARITA PCA SOUTH 4000/700
+[area21]
+shape = polygon
+altitude = 4001
+name = AA
+draw = 1
+labelpos = N35.40.00, E140.25.45
+points = 
+	N35.40.55, E140.23.15
+	N35.37.24, E140.25.45
+	N35.40.08, E140.31.28
+	N35.43.52, E140.28.45
+
+#NARITA PCA SOUTH 5000/1500
+[area22]
+shape = polygon
+altitude = 5001
+name = AA
+draw = 1
+labelpos = N35.37.51, E140.28.00
+points = 
+	N35.37.24, E140.25.45
+	N35.35.07, E140.27.23
+	N35.37.51, E140.33.08
+	N35.40.08, E140.31.28
+
+#NARITA PCA SOUTH 6000/2000
+[area23]
+shape = polygon
+altitude = 6001
+name = AA
+draw = 1
+labelpos = N35.35.39, E140.29.00
+points = 
+	N35.35.07, E140.27.23
+	N35.32.55, E140.28.58
+	N35.35.39, E140.34.43
+	N35.37.51, E140.33.08
+
+#NARITA PCA SOUTH 6000/3000
+[area24]
+shape = polygon
+altitude = 6001
+name = AA
+draw = 1
+labelpos = N35.32.55, E140.32.00
+points = 
+	N35.32.55, E140.28.58
+	N35.28.49, E140.31.55
+	N35.31.34, E140.37.39
+	N35.35.39, E140.34.43
+
+#NARITA PCA NORTH 6000/700
+[area25]
+shape = polygon
+altitude = 6001
+name = AA
+draw = 2
+labelpos = N35.53.19, E140.18.00
+points = 
+	N35.49.57, E140.16.47
+	N35.51.30, E140.15.39
+	N35.52.09, E140.17.02
+	N35.53.19, E140.16.11
+	N35.55.21, E140.20.26
+	N35.52.38, E140.22.25
+
+#NARITA PCA NORTH 6000/1500
+[area26]
+shape = polygon
+altitude = 6001
+name = AA
+draw = 4
+labelpos = N35.55.04, E140.15.39
+points = 
+	N35.51.30, E140.15.39
+	N35.55.04, E140.13.08
+	N35.57.43, E140.18.43
+	N35.55.21, E140.20.26
+	N35.53.19, E140.16.11
+	N35.52.09, E140.17.02
+
+#NARITA PCA NORTH 6000/2000
+[area27]
+shape = polygon
+altitude = 6001
+name = AA
+draw = 5
+labelpos = N35.59.00, E140.17.30
+points = 
+	N35.55.04, E140.13.08
+	N35.57.05, E140.11.41
+	N36.00.23, E140.17.23
+	N35.59.50, E140.19.45
+	N35.58.37, E140.20.38
+	N35.57.43, E140.18.43
+
+#NARITA PCA NORTH 6000/3000
+[area28]
+shape = polygon
+altitude = 6001
+name = AA
+draw = 1
+labelpos = N36.00.00, E140.11.00
+points = 
+	N35.57.05, E140.11.41
+	N36.01.17, E140.08.38
+	N36.03.15, E140.12.47
+	N36.03.17, E140.17.34
+	N36.02.26, E140.21.13
+	N35.57.33, E140.24.46
+	N35.52.38, E140.22.25
+	N35.55.21, E140.20.26
+	N35.57.43, E140.18.43
+	N35.58.37, E140.20.38
+	N35.59.50, E140.19.45
+	N36.00.23, E140.17.23
+
+#KASUMIGAURA CTR 3000/GND (EXC 3000)
+[area29]
+shape = circle
+altitude = 3000
+name = AK
+radius = 5
+position = N36.02.05, E140.11.34
+labelpos = N36.05.05, E140.08.00
+
+#TOKYO ACA FL240/FL180 (EXC FL180)
+[area30]
+shape = polygon
+altitude = 18001
+name = TY
+draw = 2
+labelpos = N35.58.00, E139.26.00
+points = 
+#8
+	N35.59.18, E139.44.24
+#50
+	N35.52.18, E139.26.08
+#56
+	N35.56.26, E139.09.39
+#59
+	N36.02.23, E139.18.42
+
+#TOKYO ACA FL240/12000 (EXC 12000)
+[area31]
+shape = polygon
+altitude = 12001
+name = TY
+draw = 3
+labelpos = N35.39.00, E139.15.00
+points = 
+#50
+	N35.52.18, E139.26.08
+#51
+	N35.47.15, E139.24.11
+#52
+	N35.23.43, E139.27.49
+#58
+	N35.21.34, E139.08.12
+#57
+	N35.43.16, E139.04.33
+#56
+	N35.56.26, E139.09.39
+
+#TOKYO ACA FL240/FL140 (EXC FL140)
+[area32]
+shape = polygon
+altitude = 14001
+name = TY
+draw = 1
+labelpos = N35.10.00, E139.18.00
+points = 
+#52
+	N35.23.43, E139.27.49
+#53
+	N35.13.01, E139.29.26
+#13
+	N34.58.11, E139.24.43
+#14
+	N34.56.14, E139.12.25
+#58
+	N35.21.34, E139.08.12
+
+#TOKYO ACA FL240/8000 (EXC 8000)
+[area33]
+shape = polygon
+altitude = 8001
+name = TY
+draw = 1
+labelpos = N35.27.00, E139.33.00
+points = 
+#8
+	N35.59.18, E139.44.24
+#9
+	N35.53.39, E139.41.46
+#10
+	N35.33.25, E139.38.40
+#11
+	N35.11.36, E139.43.10
+#12
+	N35.00.19, E139.38.18
+#13
+	N34.58.11, E139.24.43
+#53
+	N35.13.01, E139.29.26
+#52
+	N35.23.43, E139.27.49
+#51
+	N35.47.15, E139.24.11
+#50
+	N35.52.18, E139.26.08
+
+#TOKYO ACA FL240/13000 (EXC 13000)
+[area34]
+shape = polygon
+altitude = 13001
+name = AH
+draw = 1
+#labelpos = N35.19.04, E139.57.00
+points = 
+#47
+	N36.36.11, E140.26.10
+#46
+	N36.35.47, E140.26.06
+#55
+	N36.35.40, E140.28.12
+
+#TOKYO ACA FL240/10000 (EXC 10000)
+[area35]
+shape = polygon
+altitude = 10001
+name = AH
+draw = 3
+labelpos = N36.25.00, E140.36.00
+points = 
+#46
+	N36.35.47, E140.26.06
+#45
+	N36.16.28, E140.22.45
+#44
+	N36.16.19, E140.26.19
+#43
+	N36.11.52, E140.26.23
+#49
+	N36.16.30, E140.38.49
+#48
+	N36.19.13, E140.41.25
+#54
+	N36.29.38, E140.51.26
+#55
+	N36.35.40, E140.28.12
+
+#TOKYO ACA FL240/7000 (EXC 7000)
+[area36]
+shape = polygon
+altitude = 7001
+name = AH
+draw = 6
+labelpos = N36.28.00, E140.17.00
+points = 
+#6
+	N36.34.29, E140.13.17
+#29
+	N36.13.21, E140.09.30
+#36
+	N36.12.04, E140.18.53
+#35
+	N36.10.53, E140.21.47
+#41
+	N36.08.58, E140.26.26
+#43
+	N36.11.52, E140.26.23
+#44
+	N36.16.19, E140.26.19
+#45
+	N36.16.28, E140.22.45
+#46
+	N36.35.47, E140.26.06
+#47
+	N36.36.11, E140.26.10
+#42
+	N36.37.52, E140.19.37
+
+#TOKYO ACA FL240/8000 over RJAH, WEST (EXC 8000)
+[area37]
+shape = polygon
+altitude = 8001
+name = AH
+draw = 4
+labelpos = N36.14.00, E140.40.00
+points = 
+#41
+	N36.08.58, E140.26.26
+#40
+	N36.05.00, E140.36.00
+#39
+	N36.05.03, E141.00.17
+#48
+	N36.19.13, E140.41.25
+#49
+	N36.16.30, E140.38.49
+#43
+	N36.11.52, E140.26.23
+
+#TOKYO ACA FL240/8000 over RJAH, EAST (EXC 8000)
+[area38]
+shape = polygon
+altitude = 8001
+name = AH
+draw = 1
+labelpos = N36.03.00, E141.23.00
+points = 
+#17
+	N36.05.00, E141.46.04
+#18
+	N36.04.19, E141.44.09
+#19
+	N35.56.00, E141.15.34
+#20
+	N35.56.00, E141.08.41
+#39
+	N36.05.03, E141.00.17
+
+#TOKYO ACA FL240/6000 (EXC 6000)
+[area39]
+shape = polygon
+altitude = 6001
+name = AH
+draw = 4
+labelpos = N36.02.30, E140.53.00
+points = 
+#20
+	N35.56.00, E141.08.41
+#21
+	N35.56.00, E140.47.46
+#38
+	N36.02.50, E140.38.03
+#37
+	N36.04.07, E140.31.12
+#33
+	N36.04.53, E140.27.03
+#34
+	N36.06.02, E140.20.56
+#35
+	N36.10.53, E140.21.47
+#41
+	N36.08.58, E140.26.26
+#40
+	N36.05.00, E140.36.00
+#39
+	N36.05.03, E141.00.17
+
+#TOKYO ACA FL240/5000 (EXC 5000)
+[area40]
+shape = polygon
+altitude = 5001
+name = AH
+draw = 2
+labelpos = N36.01.00, E140.38.00
+points = 
+#21
+	N35.56.00, E140.47.46
+#22
+	N35.56.00, E140.38.28
+#37
+	N36.04.07, E140.31.12
+#38
+	N36.02.50, E140.38.03
+
+#TOKYO ACA FL240/4000 (EXC 4000)
+[area41]
+shape = polygon
+altitude = 4001
+name = AH
+draw = 2
+labelpos = N36.01.00, E140.31.00
+points = 
+#22
+	N35.56.00, E140.38.28
+#23
+	N35.56.00, E140.35.35
+#30
+	N35.57.32, E140.29.39
+#33
+	N36.04.53, E140.27.03
+#37
+	N36.04.07, E140.31.12
+
+#TOKYO ACA FL240/2500 (EXC 2500)
+[area42]
+shape = polygon
+altitude = 2501
+name = AH
+draw = 1
+#labelpos = 
+points = 
+#23
+	N35.56.00, E140.35.35
+#24
+	N35.56.00, E140.31.54
+#25
+	N35.56.26, E140.30.02
+#30
+	N35.57.32, E140.29.39
+
+#TOKYO ACA FL240/1800 (EXC 1800)
+[area43]
+shape = polygon
+altitude = 1801
+name = AH
+draw = 1
+#labelpos = N35.59.00, E140.22.00
+points = 
+#26
+	N35.59.30, E140.16.51
+#25
+	N35.56.26, E140.30.02
+#30
+	N35.57.32, E140.29.39
+#27
+	N36.00.23, E140.17.23
+
+#TOKYO ACA FL240/3000 (EXC 3000)
+[area44]
+shape = polygon
+altitude = 3001
+name = AH
+draw = 4
+labelpos = N36.03.00, E140.17.00
+points = 
+#32
+	N36.07.05, E140.11.34
+#31
+	N36.07.05, E140.15.14
+#34
+	N36.06.02, E140.20.56
+#33
+	N36.04.53, E140.27.03
+#30
+	N35.57.32, E140.29.39
+#27
+	N36.00.23, E140.17.23
+
+#TOKYO ACA FL240/4000 (EXC 4000)
+[area44]
+shape = polygon
+altitude = 4001
+name = AH
+draw = 6
+labelpos = N36.10.00, E140.13.00
+points = 
+#28
+	N36.06.23, E140.08.24
+#29
+	N36.13.21, E140.09.30
+#36
+	N36.12.04, E140.18.53
+#35
+	N36.10.53, E140.21.47
+#34
+	N36.06.02, E140.20.56
+#31
+	N36.07.05, E140.15.14
+#32
+	N36.07.05, E140.11.34
+
+#UTSUNOMIYA ACA 4000/GND
+[area45]
+shape = circle
+altitude = 4001
+name = TU
+radius = 15
+position = N36.29.14.36, E139.51.47.19
+labelpos = N36.22.00, E139.56.33.13
+draw = 4.6, 6.4
+
+#R-116
+[area46]
+shape = polygon
+altitude = 12001
+name = R-116
+labelpos = N34.27.00, E140.14.00
+points = 
+	N34.35.12, E140.16.48
+	N34.18.23, E140.33.06
+	N34.11.21, E140.14.09
+	N34.31.12, E140.07.48
+
+#KISARAZU CTR BLW 1000, BLW 1500, BLW 2000
+[area47]
+shape = circle
+altitude = 1500
+name = TK
+radius = 5
+position = N35.23.53.81, E139.54.35.34
+labelpos = N35.26.42, E139.57.47
+
+#SHIMOFUSA CTR 2000/GND
+[area48]
+shape = circle
+altitude = 2001
+name = TL
+radius = 5
+position = N35.47.56, E140.00.44
+labelpos = N35.48.56, E140.03.44
+
+#TATEYAMA CTR 2000/GND
+[area49]
+shape = circle
+altitude = 2001
+name = TE
+radius = 5
+position = N34.59.15, E139.49.55
+labelpos = N35.00.15, E139.46.55
+
+[approach11]
+runway = rwy1
+beacon = ARLON
+
+#ILS Z RWY 34L
+route1 = 
+	337
+#ARLON >5000
+	N35.15.25.28, E139.58.59.79
+	19.4, 5000, 200
+#APOLO >5000
+
+#ILS Z RWY 34L
+route2 = 
+	76
+#ARLON >5000
+	N35.15.25.28, E139.58.59.79
+	19.4, 5000, 200
+#APOLO >5000
+
+#ILS Z RWY 34L from CREAM
+route3 = 
+	256
+#CREAM >5000
+	N35.17.43.35, E140.06.12.42
+#ARLON >5000
+	19.4, 5000, 200
+#APOLO >5000
+
+##ILS X RWY 34L
+#route4 = 
+#	110
+##KAIHO >4000 180
+#	N35.18.57.83, E139.46.42.43, 4000, 180
+##AVION >2000
+#	N35.24.37.24, E139.51.05.50, 2000
+##ALLIE >1500 160
+#	6.4, 1500, 160
+##AZURE
+	
+
+#ILS Z RWY 34R
+[approach12]
+runway = rwy3
+beacon = CREAM
+
+#ILS Z RWY 34R from CREAM
+route1 = 
+	247
+#CREAM =4000
+	N35.17.43.35, E140.06.12.42, 4000
+#CLOAK
+	N35.15.47.98, E140.02.08.18
+#CAMEL =4000
+	17.6, 4000, 200
+#CACAO
+
+#ILS Z RWY 34R from ARLON
+route2 = 
+	360
+#ARLON >4000
+	N35.15.25.28, E139.58.59.79
+#CAMEL =4000
+	17.6, 4000, 200
+#CACAO
+
+#Y71 XAC XAC1A
+[approach13]
+runway = rwy1
+beacon = XAC
+route1 = 
+	98
+#XAC
+	N034.42.44.110, E139.24.50.460
+#ACORN =13000 230
+	N34.50.28.82, E139.41.46.71, 13000, 230
+#TT450
+	N34.52.54.0, E139.47.06.0
+#TT451
+	N34.50.16.8, E139.57.34.3
+#TT452
+	N34.51.13.2, E140.06.00.1
+#TT453
+	N34.54.38.5, E140.13.25.9
+#WANDA =13000 230
+	N35.01.55.34, E140.19.54.11, 13000, 230
+#WEDGE =8000
+	N35.09.00.44, E139.58.46.52, 8000
+#ARLON >5000
+	19.4, 5000, 200
+#APOLO >5000
+
+#RUNSO Y21 AKSEL AKSEL1A
+[approach14]
+runway = rwy1
+beacon = RUNSO
+route1 = 
+	38
+#RUNSO
+	N034.29.16.720, E139.43.04.910
+#AKSEL =12000 230
+	N034.40.39.520, E139.51.26.910, 12000, 230
+#TT454
+	N34.48.44.8, E139.57.25.3
+#TT455
+	N34.49.46.2, E140.06.35.3
+#TT456
+	N34.53.29.3, E140.14.40.2
+#WALLY =12000 230
+	N35.01.20.08, E140.21.38.60, 12000, 230
+#WEDGE =8000
+	N35.09.00.44, E139.58.46.52, 8000
+#ARLON >5000
+	19.4, 5000, 200
+#APOLO >5000
+
+#Y824 AROSA AROSA1A
+[approach15]
+runway = rwy1
+beacon = AROSA
+route1 = 
+#7
+	277
+#AROSA
+	N34.42.01.72, E140.41.57.29
+#AVEEY
+	N34.41.55.89, E140.21.57.97, 11000, 230
+#TT457
+	N34.47.14.3, E140.16.02.7
+#TT458
+	N34.48.19.1, E140.07.10.5
+#TT459
+	N34.47.12.8, E139.57.16.3
+#WALTZ
+	N34.50.14.36, E139.45.10.74, 11000, 230
+#WEDGE
+	N35.09.00.44, E139.58.46.52, 8000
+#ARLON >5000
+	19.4, 5000, 200
+#APOLO >5000
+
+route2 = 
+	7
+#RURER
+	N34.29.24.72, E140.42.01.15
+#AROSA
+	N34.42.01.72, E140.41.57.29
+#AVEEY
+	N34.41.55.89, E140.21.57.97, 11000, 230
+#TT457
+	N34.47.14.3, E140.16.02.7
+#TT458
+	N34.48.19.1, E140.07.10.5
+#TT459
+	N34.47.12.8, E139.57.16.3
+#WALTZ
+	N34.50.14.36, E139.45.10.74, 11000, 230
+#WEDGE
+	N35.09.00.44, E139.58.46.52, 8000
+#ARLON >5000
+	19.4, 5000, 200
+#APOLO >5000
+
+#Y10 GODIN GODIN1C
+[approach16]
+runway = rwy3
+beacon = CHIPS
+route1 = 
+	197
+#GODIN
+	N36.24.25.340, E140.16.55.890
+#CHIPS <13000
+	N36.12.47.70, E140.14.36.89, 13000
+#COLOR <11000
+	N36.01.16.32, E140.12.19.80, 11000
+#COPSE
+	N35.46.58.79, E140.12.05.38
+#COACH =8000
+	N35.37.36.01, E140.12.31.48, 8000, 210
+#TT465
+	N35.29.39.2, E140.12.35.4
+#TT466
+	N35.25.39.0, E140.18.40.1
+#TT467
+	N35.21.10.2, E140.21.24.4
+#EDDIE =8000
+	N35.14.47.42, E140.21.40.88, 8000, 210
+#CREAM =4000
+	N35.17.43.35, E140.06.12.42, 4000
+#CLOAK
+	N35.15.47.98, E140.02.08.18
+#CAMEL =4000
+	17.6, 4000, 200
+#CACAO
+
+
+#Y807 POLIX POLIX1C
+route2 = 
+	278
+#MILIT
+	N35.56.46.79, E141.13.08.89
+#RUSDA
+	N35.56.47.49, E140.57.29.87
+#ESKEN
+	N36.05.01.09, E140.41.22.76
+#POLIX =15000
+	N36.12.37.06, E140.26.22.53, 15000
+#CHIPS <13000
+	N36.12.47.70, E140.14.36.89, 13000
+#COLOR <11000
+	N36.01.16.32, E140.12.19.80, 11000
+#COPSE
+	N35.46.58.79, E140.12.05.38
+#COACH =8000
+	N35.37.36.01, E140.12.31.48, 8000, 210
+#TT465
+	N35.29.39.2, E140.12.35.4
+#TT466
+	N35.25.39.0, E140.18.40.1
+#TT467
+	N35.21.10.2, E140.21.24.4
+#EDDIE =8000
+	N35.14.47.42, E140.21.40.88, 8000, 210
+#CREAM =4000
+	N35.17.43.35, E140.06.12.42, 4000
+#CLOAK
+	N35.15.47.98, E140.02.08.18
+#CAMEL =4000
+	17.6, 4000, 200
+#CACAO
+
+#34L from WEDGE
+[approach17]
+runway = rwy1
+beacon = WEDGE
+route1 = 
+	9
+#WEDGE =8000
+	N35.09.00.44, E139.58.46.52, 8000
+#ARLON >5000
+	19.4, 5000, 200
+#APOLO >5000
+
+#ILS RWY 22
+[approach18]
+runway = rwy2
+beacon = NEXUS, N35.47.48.91, E139.58.29.35, 0, Nexus
+route1 = 
+	300
+#NYLON =5000
+	N35.40.18.54, E140.09.19.89, 5000
+#NIFTY =5000
+	N35.49.51.78, E140.03.55.76, 5000
+#NEXUS =5000
+	16.8, 5000, 200
+#NITRO =5000
+
+route2 = 
+	175
+#STEAM >5000
+	N35.55.53.34, E139.57.08.38
+#NINJA
+	N35.51.48.16, E139.58.55.94
+#NEXUS =5000
+	16.8, 5000, 200	
+#NITRO =5000
+
+
+#ILS Z RWY 23
+[approach19]
+runway = rwy4
+beacon = SMILE, N35.44.36.40, E140.04.00.90, -232, Smile
+route1 = 
+	160
+#STEAM =4000
+	N35.55.53.34, E139.57.08.38, 4000
+#SWEET
+	N35.53.45.19, E140.02.03.66, 4000
+#SNAKE
+	N35.52.34.97, E140.06.36.08, 4000
+#SMILE =4000
+	17.1, 4000, 200
+
+route2 = 
+	322
+#NYLON
+	N35.40.18.54, E140.09.19.89
+#SMILE
+	17.1, 4000, 200
+
+#Y71 XAC XAC1N
+[approach20]
+runway = rwy2
+beacon = XAC
+route1 = 
+	98
+#XAC
+	N034.42.44.110, E139.24.50.460
+#ACORN =13000 230
+	N34.50.28.82, E139.41.46.71, 13000, 230
+#SOLAR =13000 230
+	N34.59.09.24, E139.45.18.45, 13000, 230
+#SCOUT
+	N35.06.24.07, E139.53.56.83
+#TT250
+	N35.01.29.7, E140.03.08.5
+#TT251
+	N34.59.57.7, E140.11.36.0
+#TT252
+	N35.00.39.9, E140.20.13.0
+#STOCK =13000 230
+	N35.04.38.74, E140.30.02.93, 13000, 230
+#SHAFT =8000
+	N35.22.27.42, E140.13.13.31, 8000
+#NYLON =5000
+	N35.40.18.54, E140.09.19.89, 5000
+#NIFTY =5000
+	N35.49.51.78, E140.03.55.76, 5000
+#NEXUS =5000
+	16.8, 5000, 200
+#NITRO =5000
+
+#RUNSO Y21 AKSEL AKSEL1N
+[approach21]
+runway = rwy2
+beacon = RUNSO
+route1 = 
+	38
+#RUNSO
+	N34.29.16.72, E139.43.04.91
+#AKSEL =12000 230
+	N34.40.39.52, E139.51.26.91, 12000, 230
+#SALLY =12000 230
+	N34.53.33.89, E139.55.40.09, 12000, 230
+#TT253
+	N35.00.01.4, E140.02.24.6
+#TT254
+	N34.58.26.5, E140.11.29.4
+#TT255
+	N34.59.10.9, E140.20.41.4
+#STOWE =12000 230
+	N35.03.25.91, E140.31.11.38, 12000, 230
+#SHAFT =8000
+	N35.22.27.42, E140.13.13.31, 8000
+#NYLON =5000
+	N35.40.18.54, E140.09.19.89, 5000
+#NIFTY =5000
+	N35.49.51.78, E140.03.55.76, 5000
+#NEXUS =5000
+	16.8, 5000, 200
+#NITRO =5000
+
+
+#Y824 AROSA AROSA1N
+[approach22]
+runway = rwy2
+beacon = AROSA
+route1 = 
+	277
+#AROSA
+	N34.42.01.72, E140.41.57.29
+#AVEEY =11000 230
+	N34.41.55.89, E140.21.57.97, 11000, 230
+#TT256
+	N34.56.55.4, E140.11.22.9
+#TT257
+	N34.58.38.5, E140.01.46.6
+#SLICK =11000 230
+	N35.04.12.71, E139.51.19.99, 11000, 230
+#SHAFT =8000
+	N35.22.27.42, E140.13.13.31, 8000
+#NYLON =5000
+	N35.40.18.54, E140.09.19.89, 5000
+#NIFTY =5000
+	N35.49.51.78, E140.03.55.76, 5000
+#NEXUS =5000
+	16.8, 5000, 200
+#NITRO =5000
+
+route2 = 
+	7
+#RURER
+	N34.29.24.72, E140.42.01.15
+#AROSA
+	N34.42.01.72, E140.41.57.29
+#AVEEY =11000 230
+	N34.41.55.89, E140.21.57.97, 11000, 230
+#TT256
+	N34.56.55.4, E140.11.22.9
+#TT257
+	N34.58.38.5, E140.01.46.6
+#SLICK =11000 230
+	N35.04.12.71, E139.51.19.99, 11000, 230
+#SHAFT =8000
+	N35.22.27.42, E140.13.13.31, 8000
+#NYLON =5000
+	N35.40.18.54, E140.09.19.89, 5000
+#NIFTY =5000
+	N35.49.51.78, E140.03.55.76, 5000
+#NEXUS =5000
+	16.8, 5000, 200
+#NITRO =5000
+
+#Y10 GODIN GODIN1S
+[approach23]
+runway = rwy4
+beacon = NOVEL
+route1 = 
+	217
+#GODIN
+	N36.24.25.34, E140.16.55.89
+#NOVEL >8000
+	N36.21.06.94, E140.00.04.91
+#SCREW
+	N36.03.01.23, E139.54.00.39
+#STEAM =4000
+	N35.55.53.34, E139.57.08.38, 4000
+#SWEET
+	N35.53.45.19, E140.02.03.66, 4000
+#SNAKE
+	N35.52.34.97, E140.06.36.08, 4000
+#SMILE =4000
+	17.1, 4000, 200
+
+route2 = 
+	275
+#GODIN
+	N36.24.25.34, E140.16.55.89
+#NOVEL >8000
+	N36.21.06.94, E140.00.04.91
+#SCREW
+	N36.03.01.23, E139.54.00.39
+#STEAM =4000
+	N35.55.53.34, E139.57.08.38, 4000
+#SWEET
+	N35.53.45.19, E140.02.03.66, 4000
+#SNAKE
+	N35.52.34.97, E140.06.36.08, 4000
+#SMILE =4000
+	17.1, 4000, 200
+
+#Y807 POLIX POLIX1S
+route3 = 
+	295
+#MILIT
+	N35.56.46.79, E141.13.08.89
+#RUSDA
+	N35.56.47.49, E140.57.29.87
+#ESKEN
+	N36.05.01.09, E140.41.22.76
+#POLIX =15000
+	N36.12.37.06, E140.26.22.53, 15000
+#GODIN
+	N36.24.25.34, E140.16.55.89
+#NOVEL >8000
+	N36.21.06.94, E140.00.04.91
+#SCREW
+	N36.03.01.23, E139.54.00.39
+#STEAM =4000
+	N35.55.53.34, E139.57.08.38, 4000
+#SWEET
+	N35.53.45.19, E140.02.03.66, 4000
+#SNAKE
+	N35.52.34.97, E140.06.36.08, 4000
+#SMILE =4000
+	17.1, 4000, 200
+
+route4 = 
+	25
+#SCREW
+	N36.03.01.23, E139.54.00.39
+#STEAM =4000
+	N35.55.53.34, E139.57.08.38, 4000
+#SWEET
+	N35.53.45.19, E140.02.03.66, 4000
+#SNAKE
+	N35.52.34.97, E140.06.36.08, 4000
+#SMILE =4000
+	17.1, 4000, 200
+
+#22 from SHAFT
+[approach24]
+runway = rwy2
+beacon = SHAFT
+route1 = 
+	5
+#SHAFT =8000
+	N35.22.27.42, E140.13.13.31, 8000
+#NYLON =5000
+	N35.40.18.54, E140.09.19.89, 5000
+#NIFTY =5000
+	N35.49.51.78, E140.03.55.76, 5000
+#NEXUS =5000
+	16.8, 5000, 200
+#NITRO =5000
+
+
+[departure1]
+runway = rwy3
+
+#ROVER1B.AKAGI
+route1 = 
+	ROVER1B, Rover One Bravo Akagi
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#CLARK
+	N36.07.02.03, E139.48.00.47
+#AKAGI
+#	N36.23.28.33, E139.41.56.28
+
+#ROVER1B.AGRIS
+route2 = 
+	ROVER1B, Rover One Bravo Bruce
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#AGRIS
+	N36.25.14.70, E139.56.33.13
+
+#ROVER1B.INUBO Y808
+route3 = 
+	ROVER1B, Rover One Bravo Inubo
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#LEWIS
+	N36.13.53.15, E140.08.34.74
+#SILVA
+	N36.15.18.04, E140.17.26.04
+#INUBO
+	N35.43.35.29, E140.47.57.94
+#GULBO
+	N35.26.32.86, E141.45.09.55
+
+#ROVER1B.INUBO Y830
+route4 = 
+	ROVER1B, Rover One Bravo Inubo
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#LEWIS
+	N36.13.53.15, E140.08.34.74
+#SILVA
+	N36.15.18.04, E140.17.26.04
+#INUBO
+	N35.43.35.29, E140.47.57.94
+#BORLO
+	N35.16.33.77, E141.44.55.61
+
+#ROVER1B.INUBO Y820
+route5 = 
+	ROVER1B, Rover One Bravo Inubo
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#LEWIS
+	N36.13.53.15, E140.08.34.74
+#SILVA
+	N36.15.18.04, E140.17.26.04
+#INUBO
+	N35.43.35.29, E140.47.57.94
+#SARLU
+	N35.24.02.82, E141.11.34.06
+#ANSAD
+	N34.41.47.92, E141.42.44.41
+
+#BEKLA2B
+route6 = 
+	BEKLA2B, Bekla Two Bravo
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#INTEL
+	N35.45.53.01, E139.43.40.23
+#RAGOS
+	N35.49.42.20, E139.28.21.23
+#BEKLA
+	N35.49.58.66, E139.10.09.50
+
+#RITLA2B
+route7 = 
+	RITLA2B, Ritla Two Bravo
+#ARAKA
+	N35.38.48.83, E139.50.41.88
+#EDOJO
+	N35.42.13.98, E139.51.29.92
+#OHEDO
+	N35.45.23.40, E139.48.38.60
+#INTEL
+	N35.45.53.01, E139.43.40.23
+#LAYER
+	N35.39.25.40, E139.28.29.52
+#TIARA
+	N35.39.34.03, E139.19.54.15
+#RITLA
+	N35.39.44.78, E139.08.13.11
+
+[departure2]
+runway = rwy4, rev
+
+#BEKLA2B
+route1 = 
+	BEKLA2B, Bekla Two Bravo
+#TT501
+	N35.33.28.7, E139.50.29.9
+#TT502
+	N35.32.24.4, E139.57.20.7
+#LOCUP
+	N35.27.18.82, E139.56.08.52
+#TT503
+	N35.28.28.0, E139.48.40.4
+#KAMAT
+	N35.33.53.55, E139.41.48.89
+#LAYER
+	N35.39.25.40, E139.28.29.52
+#BEKLA
+	N35.49.58.66, E139.10.09.50
+
+#RITLA2B
+route2 = 
+	RITLA2B, Ritla Two Bravo
+#TT501
+	N35.33.28.7, E139.50.29.9
+#TT502
+	N35.32.24.4, E139.57.20.7
+#LOCUP
+	N35.27.18.82, E139.56.08.52
+#TT503
+	N35.28.28.0, E139.48.40.4
+#KAMAT
+	N35.33.53.55, E139.41.48.89
+#LAYER
+	N35.39.25.40, E139.28.29.52
+#TIARA
+	N35.39.34.03, E139.19.54.15
+#RITLA
+	N35.39.44.78, E139.08.13.11
+
+#NINOX3
+route3 = 
+	NINOX3, Ninox Three
+#TT501
+	N35.33.28.7, E139.50.29.9
+#TT502
+	N35.32.24.4, E139.57.20.7
+#LOCUP
+	N35.27.18.82, E139.56.08.52
+#BAYGE
+	N35.25.35.36, E139.43.27.42
+#SEIKO
+	N35.29.04.45, E139.30.05.04
+#NINOX
+	N35.29.53.44, E139.09.53.06
+
+#LAXAS3 Y56
+route4 = 
+	LAXAS3, Laxas Three
+#TT501
+	N35.33.28.7, E139.50.29.9
+#TT502
+	N35.32.24.4, E139.57.20.7
+#LOCUP
+	N35.27.18.82, E139.56.08.52
+#TAURA
+	N35.18.46.11, E139.44.47.34
+#IMOLA
+	N35.04.25.95, E139.29.50.95
+#LAXAS
+	N35.01.53.07, E139.14.32.78
+#KAGNA
+	N34.59.16.28, E138.59.03.81
+
+#VAMOS3.XAC B586
+route5 = 
+	VAMOS3, Vamos Three Oh shima
+#TT501
+	N35.33.28.7, E139.50.29.9
+#TT502
+	N35.32.24.4, E139.57.20.7
+#LOCUP
+	N35.27.18.82, E139.56.08.52
+#VAMOS
+	N35.12.15.47, E139.45.43.64
+#DRAKY
+	N34.53.01.73, E139.32.05.46
+#XAC
+	N34.42.44.11, E139.24.50.46
+#NURLI
+	N34.11.51.14, E139.29.47.90
+
+[departure3]
+runway = rwy1, rev
+
+#BEKLA2B
+route1 = 
+	BEKLA2B, Bekla Two Bravo
+#T6R13
+	N35.28.00.8, E139.50.06.4
+#HATBA
+	N35.26.23.40, E139.43.15.90
+#KAMAT
+	N35.33.53.55, E139.41.48.89
+#LAYER
+	N35.39.25.40, E139.28.29.52
+#BEKLA
+	N35.49.58.66, E139.10.09.50
+
+#RITLA2B
+route2 = 
+	RITLA2B, Ritla Two Bravo
+#T6R13
+	N35.28.00.8, E139.50.06.4
+#HATBA
+	N35.26.23.40, E139.43.15.90
+#KAMAT
+	N35.33.53.55, E139.41.48.89
+#LAYER
+	N35.39.25.40, E139.28.29.52
+#TIARA
+	N35.39.34.03, E139.19.54.15
+#RITLA
+	N35.39.44.78, E139.08.13.11
+
+#NINOX3
+route3 = 
+	NINOX3, Ninox Three
+#T6R12
+	N35.24.13.6, E139.52.47.1
+#TT631
+	N35.21.23.4, E139.46.48.6
+#BAYGE
+	N35.25.35.36, E139.43.27.42
+#SEIKO
+	N35.29.04.45, E139.30.05.04
+#NINOX
+	N35.29.53.44, E139.09.53.06
+
+#LAXAS3 Y56
+route4 = 
+	LAXAS3, Laxas Three
+#T6R11
+	N35.25.52.5, E139.51.37.2
+#TAURA
+	N35.18.46.11, E139.44.47.34
+#IMOLA
+	N35.04.25.95, E139.29.50.95
+#LAXAS
+	N35.01.53.07, E139.14.32.78
+#KAGNA
+	N34.59.16.28, E138.59.03.81
+
+#VAMOS3.XAC B586
+route5 = 
+	VAMOS3, Vamos Three Oh shima
+#T6R11
+	N35.25.52.5, E139.51.37.2
+#VAMOS
+	N35.12.15.47, E139.45.43.64
+#DRAKY
+	N34.53.01.73, E139.32.05.46
+#XAC
+	N34.42.44.11, E139.24.50.46
+#NURLI
+	N34.11.51.14, E139.29.47.90
+
+[departure4]
+runway = rwy3, rev
+
+#ROVER1B.AKAGI
+route1 = 
+	ROVER1B.AKAGI, Rover One Bravo Akagi
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#CLARK
+	N36.07.02.03, E139.48.00.47
+#AKAGI
+#	N36.23.28.33, E139.41.56.28
+
+#ROVER1B.AGRIS
+route2 = 
+	ROVER1B.AGRIS, Rover One Bravo Bruce
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#AGRIS
+	N36.25.14.70, E139.56.33.13
+
+#ROVER1B.INUBO Y808
+route3 = 
+	ROVER1B.INUBO Y808, Rover One Bravo Inubo
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#LEWIS
+	N36.13.53.15, E140.08.34.74
+#SILVA
+	N36.15.18.04, E140.17.26.04
+#INUBO
+	N35.43.35.29, E140.47.57.94
+#GULBO
+	N35.26.32.86, E141.45.09.55
+
+#ROVER1B.INUBO Y830
+route4 = 
+	ROVER1B.INUBO Y830, Rover One Bravo Inubo
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#LEWIS
+	N36.13.53.15, E140.08.34.74
+#SILVA
+	N36.15.18.04, E140.17.26.04
+#INUBO
+	N35.43.35.29, E140.47.57.94
+#BORLO
+	N35.16.33.77, E141.44.55.61
+
+#ROVER1B.INUBO Y820
+route5 = 
+	ROVER1B.INUBO Y820, Rover One Bravo Inubo
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#SPOON
+	N35.54.28.29, E139.53.15.98
+#ROVER
+	N35.59.18.31, E139.50.59.27
+#BRUCE
+	N36.12.00.44, E139.56.55.93
+#LEWIS
+	N36.13.53.15, E140.08.34.74
+#SILVA
+	N36.15.18.04, E140.17.26.04
+#INUBO
+	N35.43.35.29, E140.47.57.94
+#SARLU
+	N35.24.02.82, E141.11.34.06
+#ANSAD
+	N34.41.47.92, E141.42.44.41
+
+#BEKLA2B
+route6 = 
+	BEKLA2B, Bekla Two Bravo
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#INTEL
+	N35.45.53.01, E139.43.40.23
+#RAGOS
+	N35.49.42.20, E139.28.21.23
+#BEKLA
+	N35.49.58.66, E139.10.09.50
+
+#RITLA2B
+route7 = 
+	RITLA2B, Ritla Two Bravo
+#T6L23
+	N35.26.27.6, E139.55.39.1
+#WELDA
+	N35.29.41.37, E139.59.56.68
+#PLUTO
+	N35.36.32.08, E139.57.36.78
+#KAIJI
+	N35.44.09.63, E139.58.06.59
+#INTEL
+	N35.45.53.01, E139.43.40.23
+#LAYER
+	N35.39.25.40, E139.28.29.52
+#TIARA
+	N35.39.34.03, E139.19.54.15
+#RITLA
+	N35.39.44.78, E139.08.13.11
+
+
+#ILS RWY 34L
+[transition1]
+runway = rwy5
+beacon = GIINA, N35.31.20.65, E140.32.59.15, -337, Giina
+route1 = 
+	337
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+route2 = 
+	260
+#ELGAR
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+
+#ILS Z RWY 34R
+[transition2]
+runway = rwy6
+beacon = TEMIS, N35.32.01.71, E140.34.24.81, 337, Temis
+route1 = 
+	360
+#TYLER
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+route2 = 
+	270
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+[transition3]
+runway = rwy5
+beacon = NRE
+
+route1 = 
+	25
+#BAFFY
+	N34.20.42.40, E139.58.31.13
+#MAMAS
+	N34.27.33.98, E140.08.57.99
+#RUTAS
+	N34.43.49.26, E140.40.34.19
+#VENUS =11000 220
+	N35.04.40.08, E140.43.09.73, 11000, 220
+#JARED
+	N35.10.24.76, E140.52.15.40
+#AA451
+	N35.14.49.2, E140.59.11.3
+#AA452
+	N35.19.30.7, E141.02.28.5
+#AA453
+	N35.24.49.7, E141.03.42.2
+#YUMIL =11000 220
+	N35.31.58.61, E141.01.51.74, 11000, 220
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+route2 = 
+	0
+#RUTAS
+	N34.43.49.26, E140.40.34.19
+#VENUS =11000 220
+	N35.04.40.08, E140.43.09.73, 11000, 220
+#JARED
+	N35.10.24.76, E140.52.15.40
+#AA451
+	N35.14.49.2, E140.59.11.3
+#AA452
+	N35.19.30.7, E141.02.28.5
+#AA453
+	N35.24.49.7, E141.03.42.2
+#YUMIL =11000 220
+	N35.31.58.61, E141.01.51.74, 11000, 220
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+route3 = 
+	345
+#VENUS =11000 220
+	N35.04.40.08, E140.43.09.73, 11000, 220
+#JARED
+	N35.10.24.76, E140.52.15.40
+#AA451
+	N35.14.49.2, E140.59.11.3
+#AA452
+	N35.19.30.7, E141.02.28.5
+#AA453
+	N35.24.49.7, E141.03.42.2
+#YUMIL =11000 220
+	N35.31.58.61, E141.01.51.74, 11000, 220
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+route4 = 
+	180
+#SWAMP
+	N36.19.14.44, E140.32.17.02
+#VIXEN >11000
+	N36.13.35.93, E140.39.47.14
+#PLEIA
+	N36.07.34.84, E140.47.45.41
+#KARMA
+	N35.50.42.86, E140.55.12.44
+#DREAM =10000 220
+	N35.38.53.25, E141.00.23.88, 10000, 220
+#MCGEE
+	N35.32.29.00, E141.03.11.84
+#AA455
+	N35.24.48.3, E141.05.10.3
+#AA456
+	N35.19.05.7, E141.03.51.0
+#AA457
+	N35.14.03.4, E141.00.19.2
+#HYDRA =10000 220
+	N35.09.19.37, E140.52.52.52, 10000, 220
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+route5 = 
+	270
+#SUPOK
+	N35.46.14.13, E141.28.10.04
+#SOFIA =9000 220
+	N35.33.00.12, E141.11.49.94, 9000, 220
+#AA458
+	N35.24.46.9, E141.06.38.5
+#AA459
+	N35.18.40.7, E141.05.13.6
+#AA460
+	N35.13.17.5, E141.01.27.0
+#AA461
+	N35.08.14.0, E140.53.29.6
+#BELKS =9000 220
+	N35.06.38.54, E140.44.33.25, 9000, 220
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+route6 = 
+	320
+#LUBLA
+	N35.32.35.04, E141.25.50.78
+#SOFIA =9000 220
+	N35.33.00.12, E141.11.49.94, 9000, 220
+#AA458
+	N35.24.46.9, E141.06.38.5
+#AA459
+	N35.18.40.7, E141.05.13.6
+#AA460
+	N35.13.17.5, E141.01.27.0
+#AA461
+	N35.08.14.0, E140.53.29.6
+#BELKS =9000 220
+	N35.06.38.54, E140.44.33.25, 9000, 220
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+[transition4]
+runway = rwy6
+beacon = HKE
+
+route1 = 
+	25
+#BAFFY
+	N34.20.42.40, E139.58.31.13
+#MAMAS
+	N34.27.33.98, E140.08.57.99
+#RUTAS
+	N34.43.49.26, E140.40.34.19
+#JITAN
+	N34.49.14.19, E140.53.49.27
+#AQUOS
+	N35.12.29.74, E141.09.42.49
+#SIGMA <8000
+	N35.24.25.49, E141.13.18.26, 8000
+#TORCH
+	N35.37.52.84, E141.07.21.71
+#CORGI
+	N35.38.29.77, E140.51.38.90
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+route2 = 
+	355
+#RUTAS
+	N34.43.49.26, E140.40.34.19
+#JITAN
+	N34.49.14.19, E140.53.49.27
+#AQUOS
+	N35.12.29.74, E141.09.42.49
+#SIGMA <8000
+	N35.24.25.49, E141.13.18.26, 8000
+#TORCH
+	N35.37.52.84, E141.07.21.71
+#CORGI
+	N35.38.29.77, E140.51.38.90
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+route3 = 
+	345
+#JITAN
+	N34.49.14.19, E140.53.49.27
+#AQUOS
+	N35.12.29.74, E141.09.42.49
+#SIGMA <8000
+	N35.24.25.49, E141.13.18.26, 8000
+#TORCH
+	N35.37.52.84, E141.07.21.71
+#CORGI
+	N35.38.29.77, E140.51.38.90
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+route4 = 
+	180
+#SWAMP
+	N36.19.14.44, E140.32.17.02
+#VIXEN >11000
+	N36.13.35.93, E140.39.47.14
+#PLEIA
+	N36.07.34.84, E140.47.45.41
+#MIFFY >9000
+	N36.02.32.05, E140.49.59.52
+#KARMA >6000
+	N35.50.42.86, E140.55.12.44
+#UNARI
+	N35.45.13.78, E140.57.37.07
+#CORGI
+	N35.38.29.77, E140.51.38.90
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+route5 = 
+	270
+#SUPOK
+	N35.46.14.13, E141.28.10.04
+#PLOKY <9000
+	N35.45.28.26, E141.04.02.29, 9000
+#UNARI
+	N35.45.13.78, E140.57.37.07
+#CORGI
+	N35.38.29.77, E140.51.38.90
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+route6 = 
+	320
+#LUBLA
+	N35.32.35.04, E141.25.50.78
+#TORCH <9000
+	N35.37.52.84, E141.07.21.71, 9000
+#UNARI
+	N35.45.13.78, E140.57.37.07
+#CORGI
+	N35.38.29.77, E140.51.38.90
+#ELGAR
+	N35.31.29.20, E140.45.27.39
+#FIONA
+	N35.28.45.68, E140.41.25.95
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
+
+[transition5]
+runway = rwy5
+beacon = PEAKS
+route1 = 
+	330
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77, 4000
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+#ILS Z RWY 16R
+[transition6]
+runway = rwy5, rev
+beacon = ACELA, N36.07.12.79, E140.19.19.55, 0, Acela
+
+route1 = 
+	314
+#NORMA >6000
+	N35.59.00.83, E140.32.53.97
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+route2 = 
+	342
+#GEMIN >6000
+	N35.57.38.61, E140.24.50.74
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+#ILS Z RWY 16L
+[transition7]
+runway = rwy6, rev
+beacon = MARCH, N36.02.11.30, E140.17.18.80, 0, March
+
+route1 = 
+	292
+#NORMA >6000
+	N35.59.00.83, E140.32.53.97
+#LUNAR >4000 <5000
+	N35.59.50.75, E140.28.49.98, 5000
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
+
+route2 = 
+	314
+#GEMIN >4000
+	N35.57.38.61, E140.24.50.74
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
+
+[transition8]
+runway = rwy5, rev
+beacon = NRE
+
+route1 = 
+	360
+#BAFFY
+	N34.20.42.40, E139.58.31.13
+#MAMAS
+	N34.27.33.98, E140.08.57.99
+#RUTAS
+	N34.43.49.26, E140.40.34.19
+#VENUS
+	N35.04.40.08, E140.43.09.73
+#COPEN =10000 210
+	N35.33.03.70, E140.49.39.17, 10000, 210
+#BOOTH
+	N35.40.23.60, E140.51.20.47
+#AA651
+	N35.46.15.0, E140.54.57.4
+#AA652
+	N35.52.47.8, E140.55.23.8
+#GAMMA =10000 210
+	N35.58.56.27, E140.52.34.61, 10000, 210
+#CASIO =6000
+	N35.50.21.35, E140.35.56.06, 6000
+#GEMIN >6000
+	N35.57.38.61, E140.24.50.74
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+route2 = 
+	190
+#SWAMP
+	N36.19.14.44, E140.32.17.02
+#VIXEN >11000
+	N36.13.35.93, E140.39.47.14
+#PLEIA =9000 210
+	N36.07.34.84, E140.47.45.41, 9000, 210
+#BETEL
+	N35.59.31.59, E140.53.43.40
+#AA653
+	N35.52.57.7, E140.56.44.1
+#AA654
+	N35.45.57.9, E140.56.15.8
+#SPITZ =9000 210
+	N35.39.42.43, E140.52.23.89, 9000, 210
+#CASIO =6000
+	N35.50.21.35, E140.35.56.06, 6000
+#GEMIN >6000
+	N35.57.38.61, E140.24.50.74
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+route3 = 
+	270
+#SUPOK
+	N35.46.14.13, E141.28.10.04
+#AA657 250
+	N35.45.51.6, E141.12.09.1
+#REGZA =8000
+	N35.39.25.80, E141.08.09.06, 8000
+#VOGUE 210
+	N35.39.27.63, E140.59.08.40, 24000, 210
+#AA658
+	N35.45.40.9, E140.57.34.1
+#AA659
+	N35.53.07.6, E140.58.04.5
+#SAFRA =8000 210
+	N36.00.06.89, E140.54.52.20, 8000, 210
+#CASIO =6000
+	N35.50.21.35, E140.35.56.06, 6000
+#GEMIN >6000
+	N35.57.38.61, E140.24.50.74
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+route4 = 
+	320
+#LUBLA
+	N35.32.35.04, E141.25.50.78
+#REGZA =8000
+	N35.39.25.80, E141.08.09.06, 8000
+#VOGUE 210
+	N35.39.27.63, E140.59.08.40, 24000, 210
+#AA658
+	N35.45.40.9, E140.57.34.1
+#AA659
+	N35.53.07.6, E140.58.04.5
+#SAFRA =8000 210
+	N36.00.06.89, E140.54.52.20, 8000, 210
+#CASIO =6000
+	N35.50.21.35, E140.35.56.06, 6000
+#GEMIN >6000
+	N35.57.38.61, E140.24.50.74
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+[transition9]
+runway = rwy6, rev
+beacon = HKE
+
+route1 = 
+	360
+#BAFFY
+	N34.20.42.40, E139.58.31.13
+#MAMAS
+	N34.27.33.98, E140.08.57.99
+#RUTAS
+	N34.43.49.26, E140.40.34.19
+#VENUS
+	N35.04.40.08, E140.43.09.73
+#GAUDI
+	N35.30.02.42, E141.04.18.10
+#BARON
+	N35.45.51.02, E141.01.11.97
+#NORMA >6000
+	N35.59.00.83, E140.32.53.97
+#LUNAR >4000 <5000
+	N35.59.50.75, E140.28.49.98, 5000
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
+
+route2 = 
+	190
+#SWAMP
+	N36.19.14.44, E140.32.17.02
+#VIXEN >11000
+	N36.13.35.93, E140.39.47.14
+#PLEIA
+	N36.07.34.84, E140.47.45.41
+#AA655
+	N35.57.28.9, E141.01.10.3
+#AA656
+	N35.57.29.4, E141.12.09.0
+#AA657 >9000
+	N35.45.51.6, E141.12.09.1
+#BARON
+	N35.45.51.02, E141.01.11.97
+#NORMA >6000
+	N35.59.00.83, E140.32.53.97
+#LUNAR >4000 <5000
+	N35.59.50.75, E140.28.49.98, 5000
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
+
+route3 = 
+	270
+#SUPOK
+	N35.46.14.13, E141.28.10.04
+#AA657 250
+	N35.45.51.6, E141.12.09.1, 24000, 250
+#BARON
+	N35.45.51.02, E141.01.11.97
+#NORMA >6000
+	N35.59.00.83, E140.32.53.97
+#LUNAR >4000 <5000
+	N35.59.50.75, E140.28.49.98, 5000
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
+
+route4 = 
+	320
+#LUBLA
+	N35.32.35.04, E141.25.50.78
+#REGZA
+	N35.39.25.80, E141.08.09.06
+#BARON
+	N35.45.51.02, E141.01.11.97
+#NORMA >6000
+	N35.59.00.83, E140.32.53.97
+#LUNAR >4000 <5000
+	N35.59.50.75, E140.28.49.98, 5000
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
+	
+
+[transition10]
+runway = rwy5, rev
+beacon = CASIO
+
+route1 = 
+	280
+#CASIO =6000
+	N35.50.21.35, E140.35.56.06, 6000
+#GEMIN >6000
+	N35.57.38.61, E140.24.50.74
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+
+[departure5]
+runway = rwy5
+
+#TETRA8.ENPAR
+route1 = 
+	TETRA8.ENPAR, Tetra Eight Enpar
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY >13000
+	N35.53.17.39, E140.40.24.43
+#ASTON
+	N35.43.44.59, E140.25.18.63
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RAMBA >FL160
+	N35.50.03.67, E139.59.17.68
+#ENPAR
+	N35.52.05.16, E139.49.54.32
+#NIXIS
+	N35.55.05.44, E139.35.51.01
+#TEPEX
+	N36.00.14.77, E138.52.57.90
+
+#TETRA8.AGRIS
+route2 = 
+	TETRA8.AGRIS, Tetra Eight Agris
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY >13000
+	N35.53.17.39, E140.40.24.43
+#ASTON
+	N35.43.44.59, E140.25.18.63
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#AGRIS >FL200
+	N36.25.14.70, E139.56.33.13
+
+#TETRA8.KIMIN
+route3 = 
+	TETRA8.KIMIN, Tetra Eight Kimin
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY >13000
+	N35.53.17.39, E140.40.24.43
+#ASTON
+	N35.43.44.59, E140.25.18.63
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#KIMIN
+	N36.31.19.50, E140.07.38.18
+
+#REDEK2
+route4 = 
+	REDEK2, Redek Two
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY >13000
+	N35.53.17.39, E140.40.24.43
+#IBURA
+	N35.42.12.14, E140.37.59.53
+#GULID
+	N35.39.21.32, E140.28.30.25
+#PORCO
+	N35.36.24.27, E140.18.43.49
+#REDEK >FL200
+	N35.28.44.09, E139.53.33.79
+#IGNOT
+	N35.20.43.36, E139.28.15.53
+#MITOP
+	N35.19.10.75, E138.55.50.43
+
+#PIGOK2
+route5 = 
+	PIGOK2, Pigok Two
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY >13000
+	N35.53.17.39, E140.40.24.43
+#IBURA
+	N35.42.12.14, E140.37.59.53
+#ADRIA
+	N35.30.56.82, E140.35.34.30
+#ROSSO
+	N35.27.28.97, E140.24.04.40
+#PIGOK >FL200
+	N35.18.54.32, E139.55.55.63
+#TOKIS
+	N35.10.46.93, E139.30.17.54
+#SEDRI
+	N35.09.13.54, E138.57.27.34
+
+#GULBO2
+route6 = 
+	GULBO2, Gulbo Two
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY
+	N35.53.17.39, E140.40.24.43
+#CHUMS
+	N35.42.37.02, E140.48.05.95
+#CUPID
+	N35.29.30.25, E141.05.57.26
+#GULBO
+	N35.26.32.86, E141.45.09.55
+
+#BORLO2
+route7 = 
+	BORLO2, Borlo Two
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY
+	N35.53.17.39, E140.40.24.43
+#CHUMS
+	N35.42.37.02, E140.48.05.95
+#CUPID
+	N35.29.30.25, E141.05.57.26
+#BORLO
+	N35.16.33.77, E141.44.55.61
+
+#OLVAN2 Y283
+route8 = 
+	OLVAN2, Olvan Two
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY
+	N35.53.17.39, E140.40.24.43
+#CHUMS
+	N35.42.37.02, E140.48.05.95
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#GULIS
+	N34.47.05.16, E141.12.14.67
+#IRNOK
+	N34.38.32.89, E141.15.58.24
+
+#OLVAN2.SAMUS
+route9 = 
+	OLVAN2.SAMUS, Olvan Two Samus
+#ARIES >4000
+	N35.56.07.38, E140.15.05.88
+#A4L11 <7000
+	N35.59.15.6, E140.12.49.1
+#A4L12
+	N36.02.32.6, E140.16.46.8
+#A4L13
+	N36.02.36.7, E140.25.59.7
+#A4L14
+	N35.59.37.8, E140.32.05.0
+#ROONY
+	N35.53.17.39, E140.40.24.43
+#CHUMS
+	N35.42.37.02, E140.48.05.95
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#PABLO
+	N34.47.05.07, E141.03.09.59
+#NORIS
+	N34.34.26.56, E141.04.08.49
+#HANAR >FL160
+#	N34.21.49.89, E140.49.23.29
+#SAMUS
+#	N33.50.20.00, E140.13.05.00
+
+[departure6]
+runway = rwy6
+
+#TETRA8.ENPAR
+route1 = 
+	TETRA8.ENPAR, Tetra Eight Enpar
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#ASTON
+	N35.43.44.59, E140.25.18.63
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RAMBA >FL160
+	N35.50.03.67, E139.59.17.68
+#ENPAR
+	N35.52.05.16, E139.49.54.32
+#NIXIS
+	N35.55.05.44, E139.35.51.01
+#TEPEX
+	N36.00.14.77, E138.52.57.90
+
+#TETRA8.AGRIS
+route2 = 
+	TETRA8.AGRIS, Tetra Eight Agris
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#ASTON
+	N35.43.44.59, E140.25.18.63
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#AGRIS >FL200
+	N36.25.14.70, E139.56.33.13
+
+#TETRA8.KIMIN
+route3 = 
+	TETRA8.KIMIN, Tetra Eight Kimin
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#ASTON
+	N35.43.44.59, E140.25.18.63
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#KIMIN
+	N36.31.19.50, E140.07.38.18
+
+#REDEK2
+route4 = 
+	REDEK2, Redek Two
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#GULID
+	N35.39.21.32, E140.28.30.25
+#PORCO >11000
+	N35.36.24.27, E140.18.43.49
+#REDEK >FL200
+	N35.28.44.09, E139.53.33.79
+#IGNOT
+	N35.20.43.36, E139.28.15.53
+#MITOP
+	N35.19.10.75, E138.55.50.43
+
+#PIGOK2
+route5 = 
+	PIGOK2, Pigok Two
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#GULID
+	N35.39.21.32, E140.28.30.25
+#ROSSO >11000
+	N35.27.28.97, E140.24.04.40
+#PIGOK >FL200
+	N35.18.54.32, E139.55.55.63
+#TOKIS
+	N35.10.46.93, E139.30.17.54
+#SEDRI
+	N35.09.13.54, E138.57.27.34
+
+#GULBO2
+route6 = 
+	GULBO2, Gulbo Two
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#LUCCA
+	N35.41.32.82, E140.40.11.38
+#CUPID
+	N35.29.30.25, E141.05.57.26
+#GULBO
+	N35.26.32.86, E141.45.09.55
+
+#BORLO2
+route7 = 
+	BORLO2, Borlo Two
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#LUCCA
+	N35.41.32.82, E140.40.11.38
+#CUPID
+	N35.29.30.25, E141.05.57.26
+#BORLO
+	N35.16.33.77, E141.44.55.61
+
+#OLVAN2 Y283
+route8 = 
+	OLVAN2, Olvan Two
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#LUCCA
+	N35.41.32.82, E140.40.11.38
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#GULIS
+	N34.47.05.16, E141.12.14.67
+#IRNOK
+	N34.38.32.89, E141.15.58.24
+
+#OLVAN2.SAMUS
+route9 = 
+	OLVAN2.SAMUS, Olvan Two Samus
+#BOXER
+	N35.52.13.00, E140.19.51.60
+#A4R21
+	N35.55.29.4, E140.17.29.2
+#A4R22
+	N35.57.34.5, E140.21.50.1
+#A4R23
+	N35.56.38.8, E140.26.14.7
+#PEGAS
+	N035.51.26.30, E140.33.02.13
+#LUCCA
+	N35.41.32.82, E140.40.11.38
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#PABLO
+	N34.47.05.07, E141.03.09.59
+#NORIS
+	N34.34.26.56, E141.04.08.49
+#HANAR >FL160
+#	N34.21.49.89, E140.49.23.29
+#SAMUS
+#	N33.50.20.00, E140.13.05.00
+
+[departure7]
+runway = rwy5, rev
+
+#TETRA8.ENPAR
+route1 = 
+	TETRA8.ENPAR, Tetra Eight Enpar
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R11
+	N35.30.56.9, E140.33.16.2
+#A6R13
+	N35.26.54.9, E140.24.52.6
+#A6R14
+	N35.33.24.7, E140.20.11.9
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RAMBA >FL160
+	N35.50.03.67, E139.59.17.68
+#ENPAR
+	N35.52.05.16, E139.49.54.32
+#NIXIS
+	N35.55.05.44, E139.35.51.01
+#TEPEX
+	N36.00.14.77, E138.52.57.90
+
+#TETRA8.AGRIS
+route2 = 
+	TETRA8.AGRIS, Tetra Eight Agris
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R11
+	N35.30.56.9, E140.33.16.2
+#A6R13
+	N35.26.54.9, E140.24.52.6
+#A6R14
+	N35.33.24.7, E140.20.11.9
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#AGRIS >FL200
+	N36.25.14.70, E139.56.33.13
+
+#TETRA8.KIMIN
+route3 = 
+	TETRA8.KIMIN, Tetra Eight Kimin
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R11
+	N35.30.56.9, E140.33.16.2
+#A6R13
+	N35.26.54.9, E140.24.52.6
+#A6R14
+	N35.33.24.7, E140.20.11.9
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#KIMIN
+	N36.31.19.50, E140.07.38.18
+
+#REDEK2
+route4 = 
+	REDEK2, Redek Two
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R12
+	N35.25.43.5, E140.37.00.7
+#KUJYU >11000
+	N35.21.03.95, E140.27.19.84
+#REDEK >FL200
+	N35.28.44.09, E139.53.33.79
+#IGNOT
+	N35.20.43.36, E139.28.15.53
+#MITOP
+	N35.19.10.75, E138.55.50.43
+
+#PIGOK2
+route5 = 
+	PIGOK2, Pigok Two
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R12
+	N35.25.43.5, E140.37.00.7
+#KUJYU >11000
+	N35.21.03.95, E140.27.19.84
+#PIGOK >FL200
+	N35.18.54.32, E139.55.55.63
+#TOKIS
+	N35.10.46.93, E139.30.17.54
+#SEDRI
+	N35.09.13.54, E138.57.27.34
+
+#GULBO2
+route6 = 
+	GULBO2, Gulbo Two
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R12
+	N35.25.43.5, E140.37.00.7
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#TAPIR >FL160
+	N35.20.28.50, E141.26.21.89
+#GULBO
+	N35.26.32.86, E141.45.09.55
+
+#BORLO2
+route7 = 
+	BORLO2, Borlo Two
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R12
+	N35.25.43.5, E140.37.00.7
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#GRAYL >FL160
+	N35.15.04.83, E141.29.37.95
+#BORLO
+	N35.16.33.77, E141.44.55.61
+
+#OLVAN2 Y283
+route8 = 
+	OLVAN2, Olvan Two
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R12
+	N35.25.43.5, E140.37.00.7
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#GULIS
+	N34.47.05.16, E141.12.14.67
+#IRNOK
+	N34.38.32.89, E141.15.58.24
+
+#OLVAN2.SAMUS
+route9 = 
+	OLVAN2.SAMUS, Olvan Two Samus
+#ASPEN
+	N35.34.51.00, E140.30.28.10
+#A6R12
+	N35.25.43.5, E140.37.00.7
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#PABLO
+	N34.47.05.07, E141.03.09.59
+#NORIS
+	N34.34.26.56, E141.04.08.49
+#HANAR >FL160
+#	N34.21.49.89, E140.49.23.29
+#SAMUS
+#	N33.50.20.00, E140.13.05.00
+
+[departure8]
+runway = rwy6, rev
+
+#TETRA8.ENPAR
+route1 = 
+	TETRA8.ENPAR, Tetra Eight Enpar
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#AA631
+	N35.36.19.9, E140.44.31.9
+#AA632
+	N35.44.46.7, E140.38.28.9
+#PHLOX >FL160
+	N35.45.56.60, E140.22.46.08
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RAMBA >FL160
+	N35.50.03.67, E139.59.17.68
+#ENPAR
+	N35.52.05.16, E139.49.54.32
+#NIXIS
+	N35.55.05.44, E139.35.51.01
+#TEPEX
+	N36.00.14.77, E138.52.57.90
+
+#TETRA8.AGRIS
+route2 = 
+	TETRA8.AGRIS, Tetra Eight Agris
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#AA631
+	N35.36.19.9, E140.44.31.9
+#AA632
+	N35.44.46.7, E140.38.28.9
+#PHLOX >FL160
+	N35.45.56.60, E140.22.46.08
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#AGRIS >FL200
+	N36.25.14.70, E139.56.33.13
+
+#TETRA8.KIMIN
+route3 = 
+	TETRA8.KIMIN, Tetra Eight Kimin
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#AA631
+	N35.36.19.9, E140.44.31.9
+#AA632
+	N35.44.46.7, E140.38.28.9
+#PHLOX >FL160
+	N35.45.56.60, E140.22.46.08
+#TETRA >12000
+	N35.46.26.37, E140.15.55.78
+#RADIX >FL150
+	N35.59.17.17, E140.09.33.22
+#WHARF >FL180
+	N36.07.22.55, E140.05.31.14
+#KIMIN
+	N36.31.19.50, E140.07.38.18
+
+#REDEK2
+route4 = 
+	REDEK2, Redek Two
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#AA631
+	N35.36.19.9, E140.44.31.9
+#AA632
+	N35.44.46.7, E140.38.28.9
+#ACURE
+	N35.45.35.60, E140.27.32.33
+#PAGOT >FL160
+	N35.40.39.63, E140.21.39.44
+#REDEK >FL200
+	N35.28.44.09, E139.53.33.79
+#IGNOT
+	N35.20.43.36, E139.28.15.53
+#MITOP
+	N35.19.10.75, E138.55.50.43
+
+#PIGOK2
+route5 = 
+	PIGOK2, Pigok Two
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#AA631
+	N35.36.19.9, E140.44.31.9
+#AA632
+	N35.44.46.7, E140.38.28.9
+#ACURE
+	N35.45.35.60, E140.27.32.33
+#PAGOT >FL160
+	N35.40.39.63, E140.21.39.44
+#PIGOK >FL200
+	N35.18.54.32, E139.55.55.63
+#TOKIS
+	N35.10.46.93, E139.30.17.54
+#SEDRI
+	N35.09.13.54, E138.57.27.34
+
+#GULBO2
+route6 = 
+	GULBO2, Gulbo Two
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#TAPIR >FL160
+	N35.20.28.50, E141.26.21.89
+#GULBO
+	N35.26.32.86, E141.45.09.55
+
+#BORLO2
+route7 = 
+	BORLO2, Borlo Two
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#GRAYL >FL160
+	N35.15.04.83, E141.29.37.95
+#BORLO
+	N35.16.33.77, E141.44.55.61
+
+#OLVAN2 Y283
+route8 = 
+	OLVAN2, Olvan Two
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#GULIS
+	N34.47.05.16, E141.12.14.67
+#IRNOK
+	N34.38.32.89, E141.15.58.24
+
+#OLVAN2.SAMUS
+route9 = 
+	OLVAN2.SAMUS, Olvan Two Samus
+#BEAMS
+	N35.35.33.00, E140.31.53.10
+#A6L21
+	N35.31.37.9, E140.34.41.9
+#OLVAN
+	N35.12.14.13, E141.01.11.31
+#PABLO
+	N34.47.05.07, E141.03.09.59
+#NORIS
+	N34.34.26.56, E141.04.08.49
+#HANAR >FL160
+#	N34.21.49.89, E140.49.23.29
+#SAMUS
+#	N33.50.20.00, E140.13.05.00
+
+[configurations]
+config1 = 
+	0, rwy3, landstart
+	0, rwy4, startrev
+	0, rwy1, land
+	0, rwy5, landstart
+	0, rwy6, landstart
+
+config2 = 
+	0, rwy3, startrev
+	0, rwy4, land
+	0, rwy1, startrev
+	0, rwy2, land
+	0, rwy5, landstartrev
+	0, rwy6, landstartrev
+
+
+
+[planetypes]
+types = 
+	hdjt, 6, 140, 360, 2.8, 3.2, 1500, 1800, 115, 125, 1.3, 1.5, honda jet

--- a/final/AS/JPN/RJTT_readme.md
+++ b/final/AS/JPN/RJTT_readme.md
@@ -1,4 +1,4 @@
-# RJTT ACA 1.2
+# RJTT ACA 1.3.1
 
 This is an implementation of the TOKYO ACA (Approach Control Area) for [Endless ATC](https://steamcommunity.com/app/666610) featuring RJTT Tokyo International Airport (commonly referred to as Haneda) and RJAA Narita International Airport.
 

--- a/final/AS/JPN/RJTT_readme.md
+++ b/final/AS/JPN/RJTT_readme.md
@@ -52,7 +52,7 @@ There are four runways:
 
 A few different configurations are used in real operations, but only two are available in this version of RJTT ACA:
 
--	Landing 34L/34R, departing 34R/23
+-	Landing 34L/34R, departing 34R/05
 	
 	In general, arrivals from the southwest (XAC, AKSEL, AROSA) land 34L and arrivals from the northeast (GODIN, POLIX) land 34R. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
 

--- a/final/AS/JPN/RJTT_readme.md
+++ b/final/AS/JPN/RJTT_readme.md
@@ -1,0 +1,187 @@
+# RJTT ACA 1.2
+
+This is an implementation of the TOKYO ACA (Approach Control Area) for [Endless ATC](https://steamcommunity.com/app/666610) featuring RJTT Tokyo International Airport (commonly referred to as Haneda) and RJAA Narita International Airport.
+
+Based upon AIP Japan 2020/10/08. The choice of SIDs and STARs may not be 100% accurate to real life but should be reasonably accurate reflecting IFR conditions and daytime environment.
+
+To activate a STAR, a plane must be flying direct to an applicable fix, then the APP button can be activated.
+
+JSDF-G bases RJTL Shimofusa, RJTE Tateyama, RJTK Kisarazu are not represented as it appears traffic should mostly be military helicopters, which I don't know how to represent in this game.
+RJTO Oshima/RJAN Niijima are not represented as traffic is either helicopters or traffic to RJTF Chofu in RJTY Yokota ACA. Unfortunately traffic to RJTY is difficult to represent as RJTT ACA has airspace on top of most of RJTY ACA, meaning that within the game, it is not possible to get planes to "spawn" from the appropriate region.
+
+## Airports
+
+### RJTT
+
+The main airport of this sector. Previously only handling domestic traffic and very limited international flights to key East Asian cities, Haneda now handles a fair amount of international traffic along with most of Tokyo's domestic traffic. As such, traffic is biased towards the west for departures and southwest for arrivals. 
+
+There is custom traffic for RJTT. The proportions are very much estimates but shouldn't be too far off from reality.
+
+Most fixes visible on the map have a defined hold including many fixes along the STARs. The published hold for missed approaches is UTIBO for 34L/23 and KASGA for 34R/22.
+
+Aircraft arrive at 6 points:
+
+- SPENS -> XAC (west from western Japan, Korea, Northern China)
+- SELNO -> RUNSO (-> AKSEL) (south west from southwestern Japan, Okinawa, Southeast Asia)
+- TOPIT -> LUTNA -> RURER -> AROSA (south from Hachijojima, Indonesia/Australia)
+- DOLBA -> AROSA (southeast from oceanic, Australia/NZ/Pacific islands, Guam)
+- TEDIX -> GODIN (-> CHIPS) (north from northern Japan, Russia, Europe, east NA)
+- LALID -> MILIT -> RUSDA -> ESKEN -> POLIX (-> CHIPS) (east from oceanic, west NA/SA, Hawaii)
+
+Aircraft depart via:
+
+- CLARK (northnorthwest for Russia/Europe)
+- AGRIS (north for northern Japan and beyond)
+- GULBO (northeastern oceanic)
+- BORLO (east oceanic)
+- ANSAD (southeastern oceanic)
+- NURLI (south)
+- KAGNA (southwest and Osaka)
+- NINOX (west for southern western Japan and beyond)
+- RITLA (west for central western Japan and beyond)
+- BEKLA (northwest such as Korea/north China/north side of western Japan)
+
+(VAMOS departures to UTIBO aren't implemented as there are no standard flight planned routes from RJTT that use this transition.)
+
+There are four runways:
+
+- 16R/34L (RWY A) 
+- 04/22 (RWY B)
+- 16L/34R (RWY C)
+- 05/23 (RWY D)
+
+A few different configurations are used in real operations, but only two are available in this version of RJTT ACA:
+
+-	Landing 34L/34R, departing 34R/23
+	
+	In general, arrivals from the southwest (XAC, AKSEL, AROSA) land 34L and arrivals from the northeast (GODIN, POLIX) land 34R. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
+
+	34L handles the higher amounts of traffic from the southwest, and 05 handles the higher amounts of traffic heading southwest. The lower amounts of traffic to/from the northeast share 34R in mixed operation. 04 is not used in this configuration as it conflicts with landings on 34L (in real life, it may be used for some GA departures?).
+
+	Approaches to 34L (RWY *A*) and 34R (RWY *C*) are available using APP mode from *A*RLON and *C*REAM respectively, with transitions from ARLON or CREAM depending whether the aircraft is approaching from the south or the east.
+
+	STARS are available using approach mode from XAC, RUNSO, AROSA, and \**CHIPS*\*. STARS to 34L/34R implement a point merge system around WEDGE for 34L and CREAM for 34R. Aircraft fly an arc around a point (WEDGE/CREAM), and you can sequence planes by directing planes to proceed direct WEDGE/CREAM and activate APP mode. 
+
+	Note that FL130 arrivals from XAC will conflict with FL120 arrivals from AKSEL when descending from the point merge arc to meet the =8000 restriction at WEDGE. Either descend the AKSEL arrival (watch out for AROSA arrivals at FL110) or prioritize the AKSEL arrival over the XAC arrival. Also watch for AROSA arrivals conflicting with arrivals to RJAA.
+
+	\***Departures to the west and north will need to handed off before they reach the boundary of the ACA**, *as they will NOT climb out of the ACA.*\*
+
+	Note that the normal runway operation for 34L/34R arrivals (HIGHWAY VISUAL 34R and ILS X 34L from KAIHO) is not possible to implement due to the lack of visual approaches in the game and the fact that aircraft joining the parallel ILS above RJTK Kisarazu would conflict as they are at the same altitude. Therefore the approaches depicted are illustrative of IFR conditions necessitating the use of long ILS approaches for both runways.
+
+	For an extra challenge, try routing ANA/VIP flights to 34R (T2/VIP area) and JAL/international/GA/JCAB flights to 34L (T1/T3/N area).
+
+-	Landing 22/23, departing 16L/16R
+	
+	In general, arrivals from the southwest (XAC, AKSEL, AROSA) land **\*22\*** and arrivals from the northeast (GODIN, POLIX) land **\*23\***. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
+
+	22/16R handles the higher amounts of traffic to/from the southwest as they do not conflict with other runways (16R departures depart before the intersection with 22). As RWY23 arrivals conflict with departures from both 16s, it is used for traffic arriving from the northeast.
+
+	Approaches to 22 and 23 are available using APP mode from NEXUS and SMILE respectively, with transitions from *N*YLON or *S*TEAM depending whether the aircraft is approaching from the *n*orth or the *s*outh.
+
+	STARS are available using approach mode from XAC, RUNSO, AROSA, and \**NOVEL*\*. STARs from the southwest implement a point merge system around SHAFT (STARs from the northeast are traditional). Aircraft fly an arc around a SHAFT, and you can sequence planes by directing planes to proceed direct SHAFT and activate APP mode. 
+
+	\***Departures to the west and north will need to handed off before they reach the boundary of the ACA**, *as they will NOT climb out of the ACA.*\*
+
+	Note that the normal runway operation for 22/23 arrivals (LDA W RWY22/RWY23) is not possible to implement due to the lack of LDA approaches in the game. Therefore the approaches depicted are illustrative of IFR conditions necessitating the use of straight-in ILS approaches for both runways. However, note that the slight offset of the ILS for 23 isn't represented, the game does not appear to respect the 2 degree offset defined at this time.
+
+	For an extra challenge, try routing ANA/VIP flights to 23 (T2/VIP area) and JAL/international/GA flights to 22 (T1/T3/N area).
+
+### RJAA
+
+The secondary, yet also major airport of this sector. Previously handling almost all of Tokyo's international traffic, it has lost some of it to Haneda recently. However, it still handles a large chunk of Tokyo's international flights as well as the many cargo flights from FDX/UPS etc. RWY 34R which was too short when Narita opened to handle heavy aircraft has now been extended and can generally handle most aircraft other than the largest of aircraft such as A388.
+
+There is custom traffic for RJAA. The proportions are very much estimates but shouldn't be too far off from reality.
+
+Most fixes visible on the map have a defined hold including many fixes along the STARs. The published hold for missed approaches is SWIMY for 16R/34L and ABBOT for 16L/34R.
+
+Aircraft arrive at 4 points:
+
+- BAFFY -> MAMAS -> RUTAS (southwest from western and southwestern)
+- VAGLA -> LUBLA (northeast oceanic)
+- LESPO -> SUPOK (southeast oceanic)
+- GURIR -> SWAMP (north from north, northwest and northeast)
+
+Aircraft depart via:
+
+- AGRIS (northwest)
+- KIMIN (north)
+- GULBO (northeast oceanic)
+- BORLO (east oceanic)
+- IRNOK (southsoutheast oceanic)
+- NORIS (south oceanic)
+- SEDRI (southwest)
+- MITOP (west)
+- TEPEX (northwest)
+
+There are two runways:
+
+- 16R/34L (RWY A) 
+- 16L/34R (RWY B)
+
+There are two simple runway configurations:
+
+-	Landing and departing 34L/34R
+
+	Approaches to 34L and 34R are available using APP mode from GIINA and TEMIS respectively, with transitions from TYLER or ELGAR depending whether the aircraft is approaching from the south or the east.
+
+	Arrivals enter the ACA inbound direct NRE due to game limitations, however STARs are available using approach mode from NRE/HKE at the north end of each runway, with the appropriate STAR chosen depending on the aircraft's bearing to NRE/HKE starting from BAFFY, SUPOK, LUBLA, or SWAMP. STARS to 34L from NRE implement a point merge system around PEAKS. Aircraft fly an arc around PEAKS, and you can sequence planes by directing planes to proceed direct PEAKS and activate APP mode. 
+
+	Note that higher altitude arrivals on the arc will conflict with lower altitude arrivals descending from the point merge arc to meet the =6000 restriction at PEAKS. Either descend the lower altitude arrival (watch out for even lower altitude arrivals) or prioritize the lower altitude arrival over the higher altitude arrival.
+
+	34R stars are traditional STARs, watch out for potential conflicts with arrivals on STARs to 34L.
+
+	For arrivals from RUTAS, watch out for conflicts with AROSA arrivals to RJTT.
+
+	Departures are executed in parallel and maintain horizontal separation until east of RJAA. Recommend not assigning higher than 7000 to 34L departures until clear of RJTT arrivals from GODIN/POLIX.
+
+	For an extra challenge, try routing oneworld/LCC flights to 34R (T2/T3) and other flights to 34L (T1/cargo area).
+
+-	Landing 22/23, departing 16L/16R
+
+	Approaches to 16L and 16R are available using APP mode from MARCH and ACELA respectively, with transitions from TYLER or ELGAR depending whether the aircraft is approaching from the south or the east.
+
+	Arrivals enter the ACA inbound direct NRE due to game limitations, however STARs are available using approach mode from NRE/HKE at the north end of each runway, with the appropriate STAR chosen depending on the aircraft's bearing to NRE/HKE starting from BAFFY, SUPOK, LUBLA, or SWAMP. STARS to 16R from NRE implement a point merge system around CASIO. Aircraft fly an arc around CASIO, and you can sequence planes by directing planes to proceed direct CASIO and activate APP mode. 
+
+	Note that higher altitude arrivals on the arc will conflict with lower altitude arrivals descending from the point merge arc to meet the =6000 restriction at CASIO. Either descend the lower altitude arrival (watch out for even lower altitude arrivals) or prioritize the lower altitude arrival over the higher altitude arrival.
+
+	16L stars are traditional STARs, watch out for potential conflicts with arrivals on STARs to 16R.
+
+	Use care not to descend arrivals into RJAH/RJAK airspace.
+
+	For an extra challenge, try routing oneworld/LCC flights to 16L (T2/T3) and other flights to 16R (T1/cargo area).
+
+## Known Issues
+
+- No RJTT LDA 22/23 due to game limitations (no LDA approaches, not enough approach slots).
+- Missing offset for RJTT ILS 23 due to game bug???
+- Shortcuts for arrivals via direct to fix is limited to a few fixes due to game limitations (not enough approach slots).
+- No RJTT 16L/16R due to game limitations (not enough approach slots).
+- No fair weather 34L/34R approach usage (no visual approaches, conflict on joining parallel ILS at same altitude)
+- No RJTO (not possible to model arrivals from RJTY ACA)
+- SELNO arrivals spawn a bit inside the ACA with no warning.
+- Arrival and departure directions can be a bit nonsense (e.g. AHK arriving from the Pacific), unfortunately this appears to be a game limitation.
+
+## Changelog
+
+*	1.0 - 2020/10/19 - Initial version.
+*	1.1 - 2020/10/19
+	- Add RJAA.
+	- bug fixes
+*	1.2 - 2020/10/23
+	- Flesh out airspace (RJTT/RJAA CTR/PCA, airspace over RJAH/RJTY/RJTU ACA, RJTL/RJTE/RJTK CTR)
+	- Adjustments to entry points
+	- Remove hack as multiple departures on one runway work now
+	- Add basic SIDs to show exit fixes
+	- Display minor fixes using basic SID exit fixes
+	- Correct name of RJTT
+	- Correct reading of OLVAN2.SAMUS STAR
+	- Correct spelling of BEKLA2B SID
+	- Fix approaches from GIINA, TEMIS, ACELA, MARCH to actually work
+	- Add case for approach from NOVEL when already south of NOVEL
+*	1.3 - 2020/10/24
+	- Extend RJTT LAXAS SID to KAGNA
+	- Shorten RJTT ROVER SID AKAGI transition to the exit point from the ACA, CLARK
+	- Add RJTT VAMOS SID XAC transition to B586
+	- Adjusted entry points
+	- Adjust label for Shimofusa CTR
+	- Add readme

--- a/final/AS/JPN/RJTT_readme.md
+++ b/final/AS/JPN/RJTT_readme.md
@@ -185,3 +185,5 @@ There are two simple runway configurations:
 	- Adjusted entry points
 	- Adjust label for Shimofusa CTR
 	- Add readme
+*	1.3.1 - 2020/10/25
+	- Correct CCA callsign pronunciation for RJAA


### PR DESCRIPTION
Submitting a version of Tokyo Approach Control Area that is much larger and realistic compared to the default one, and includes RJAA Narita Intl as well.