### PR TITLE
Make it a bit easier to debug when airlines= is malformed

### DIFF
--- a/final/AS/HKG/source/VHHH_PC.txt
+++ b/final/AS/HKG/source/VHHH_PC.txt
@@ -1,6 +1,7 @@
 [meta]
 header = VHHH TMA 1.0.0
 	See VHHH_PC_readme.md
+callsigns = True
 
 [airspace]
 radius = 100


### PR DESCRIPTION
Now when airlines= parsing borks, the exception message shows what was being processed at the time of bork.

Accidentally included a change to `VHHH` I made for testing, but it doesn't change the resulting product (just updates it to work with current version of `deploy.py`) so might as well merge it in...