### PR TITLE
add eddm version 1.4

### DIFF
--- a/final/EU/DEU/EDDM.txt
+++ b/final/EU/DEU/EDDM.txt
@@ -1,4 +1,4 @@
-# EDDM v1.3
+# EDDM v1.4
 # Munich Airport "Franz Josef Strauß" in the south of Germany.
 
 [airspace]
@@ -8,11 +8,15 @@ center = N48.353802, E11.7861
 magneticvar = 1.596
 floor = 3700
 descendaltitude = 11000
-ceiling = 13000
+ceiling = 12500
 above = 19000
 transitionaltitude = 6000
 usa = false
 speedrestriction = 2, 250
+name = munich radar, munich radar
+handoff =
+	360, München Radar, munich radar, 128.625
+	180, München Radar, munich radar, 132.405
 
 boundary = 
 	N48.705608, E11.9316
@@ -158,8 +162,8 @@ line2 =
 name = Munich Airport
 code = EDDM
 runways =
-	rwyn, 08L, N48.3628, E11.7676, 83.4, 13123, 0, 0, 1467
-	rwys, 08R, N48.3407, E11.751, 83.4, 13123, 0, 0, 1486
+	rwyn, 08L, N48.3628, E11.7676, 83.4, 13123, 0, 0, 1467, 3, 0, 3, 0, 0, 0, 0, 0, 118.705
+	rwys, 08R, N48.3407, E11.751, 83.4, 13123, 0, 0, 1486, 3, 0, 3, 0, 0, 0, 0, 0, 120.505
 
 entrypoints = 
 	40, landu
@@ -342,14 +346,6 @@ route4 =
 # DM053, AMPEG, MERSI
 
 route5 = 
-	OBA6S, obaxa six sierra
-	N48.337669, E11.709431
-	N48.230222, E11.706375
-	N48.094592, E11.739131
-	N48.012222, E11.665556
-# DM049, DM068, DM069, OBAXA
-
-route6 = 
 	ROT3S, rotax three sierra
 	N48.337669, E11.709431
 	N48.287569, E11.708006
@@ -358,7 +354,7 @@ route6 =
 	N47.977450, E12.384081
 # DM049, DM050, OTT, LAKOL, ROTAX
 
-route7 = 
+route6 = 
 	TUL3S, tulsi six sierra
 	N48.337669, E11.709431
 	N48.287569, E11.708006
@@ -366,7 +362,7 @@ route7 =
 	N47.701608, E11.788758
 # DM049, DM050, OTT, TULSI
 
-route8 = 
+route7 = 
 	TUR7S, turbu seven sierra
 	N48.337669, E11.709431
 	N48.287569, E11.708006
@@ -374,7 +370,7 @@ route8 =
 	N47.914083, E11.948703
 # DM049, DM050, OTT, TURBU
 
-route9 = 
+route8 = 
 	VAV3S, vavor three sierra
 	N48.337669, E11.709431
 	N48.287569, E11.708006

--- a/final/EU/DEU/EDDM_Readme.md
+++ b/final/EU/DEU/EDDM_Readme.md
@@ -8,7 +8,7 @@ Second hub of Lufthansa, offering many international and intercontinental routes
 
 - The approaches are meant to help coordination during high traffic. During low traffic, controllers usually skip the transitions completely and vector to final, sometimes giving directs to waypoints.
 - Departures are cleared to FL70, meaning that they might have to pass below approaching traffic following the transitions. This is one reason why vectoring arriving planes can be handy, as you can keep more space between arrivals and departures.
-- Skill Cap 16 works fine so that some planes can still depart between the arrivals.
+- Maximum Skill Cap 16 works fine so that some planes can still depart between the arrivals.
 
 ## Already working:
 - most SIDs exist
@@ -25,6 +25,12 @@ Second hub of Lufthansa, offering many international and intercontinental routes
 - check if arrival entry directions make sense, same for descent altitude
 
 ## Changelog
+
+### v1.4
+
+- reduce ceiling to make departure diversions less likely
+- add radar name for arriving traffic, added handover frequencies for departures and arrivals (tower)
+- remove obaxa 6s departure route that is not used for jet aircraft
 
 ### v1.3
 


### PR DESCRIPTION
- reduce ceiling to make departure diversions less likely
- add radar name for arriving traffic, added handover frequencies for departures and arrivals (tower)
- remove obaxa 6s departure route that is not used for jet aircraft